### PR TITLE
Fixed 500 HTTP error when renaming a version to a name that already e…

### DIFF
--- a/server/resources/abstract_resource.py
+++ b/server/resources/abstract_resource.py
@@ -47,10 +47,10 @@ class AbstractVRResource(Resource):
         try:
             pathvalidate.validate_filename(name, platform='Linux')
         except pathvalidate.ValidationError:
-            raise ValueError('Invalid file name: ' + name, 400)
+            raise RestException('Invalid file name: ' + name, code=400)
         try:
             Folder().find({'parentId': parentFolder['_id'], 'name': name}, limit=1).next()
-            raise ValueError('Name already exists: ' + name, 400)
+            raise RestException('Name already exists: ' + name, code=409)
         except StopIteration:
             pass
 

--- a/server/resources/version.py
+++ b/server/resources/version.py
@@ -69,6 +69,7 @@ class Version(AbstractVRResource):
         .errorResponse('Access was denied (if current user does not have write access to this '
                        'tale)', 403)
         .errorResponse('Illegal file name', 400)
+        .errorResponse('Name already exists', 409)
     )
     def rename(self, vfolder: dict, newName: str) -> dict:
         return super().rename(vfolder, newName)


### PR DESCRIPTION
…xists. The error code should be 409. Also fixed the same when an invalid name was supplied and respond with HTTP 400 instead.
Fixes #8 