### PR TITLE
Made API more REST like and replaced the idea of a root folder by sim…

### DIFF
--- a/server/resources/run.py
+++ b/server/resources/run.py
@@ -51,17 +51,17 @@ class Run(AbstractVRResource):
         Description('Clears all runs from a tale, but does not delete the respective '
                     'directories on disk. This is an administrative operation and should not be'
                     'used under normal circumstances.')
-        .modelParam('rootId', 'The ID of the runs root folder', model=Folder, force=True,
-                    destName='root', paramType='query')
+        .modelParam('taleId', 'The ID of the runs root folder', model=Tale, force=True,
+                    destName='tale', paramType='query')
     )
-    def clear(self, root: dict) -> None:
-        super().clear(root)
+    def clear(self, tale: dict) -> None:
+        super().clear(tale)
 
     @access.user(TokenScope.DATA_WRITE)
     @filtermodel('folder')
     @autoDescribeRoute(
         Description('Rename a run associated with a tale. Returns the renamed run folder')
-        .modelParam('id', 'The ID of run folder', model=Folder, force=True,
+        .modelParam('id', 'The ID of a run', model=Folder, force=True,
                     destName='rfolder')
         .param('newName', 'The new name', required=True, dataType='string', paramType='query')
         .errorResponse('Access was denied (if current user does not have write access to this '
@@ -73,8 +73,8 @@ class Run(AbstractVRResource):
 
     @access.user(TokenScope.DATA_READ)
     @autoDescribeRoute(
-        Description('Returns a runs folder.')
-        .modelParam('id', 'The ID of a run folder', model=Folder, force=True,
+        Description('Returns a run.')
+        .modelParam('id', 'The ID of a run.', model=Folder, force=True,
                     destName='rfolder')
         .errorResponse('Access was denied (if current user does not have read access to the '
                        'respective run folder.', 403)
@@ -115,7 +115,7 @@ class Run(AbstractVRResource):
     @access.user(TokenScope.DATA_WRITE)
     @autoDescribeRoute(
         Description('Deletes a run.')
-        .modelParam('id', 'The ID of run folder', model=Folder, force=True,
+        .modelParam('id', 'The ID of run', model=Folder, force=True,
                     destName='rfolder')
         .errorResponse('Access was denied (if current user does not have write access to this '
                        'tale)', 403)
@@ -137,28 +137,28 @@ class Run(AbstractVRResource):
     @access.user(TokenScope.DATA_READ)
     @filtermodel('folder')
     @autoDescribeRoute(
-        Description('Lists all runs.')
-        .modelParam('rootId', 'The ID of runs root folder.', model=Folder, force=True,
-                    destName='root')
+        Description('Lists runs.')
+        .modelParam('taleId', 'The ID of the tale to which the runs belong.', model=Tale,
+                    force=True, destName='tale')
         .pagingParams(defaultSort='created')
         .errorResponse('Access was denied (if current user does not have read access to this '
                        'tale)', 403)
     )
-    def list(self, root: dict, limit, offset, sort):
-        return super().list(root, limit, offset, sort)
+    def list(self, tale: dict, limit, offset, sort):
+        return super().list(tale, limit, offset, sort)
 
     @access.user(TokenScope.DATA_READ)
     @autoDescribeRoute(
         Description('Check if a run exists.')
-        .modelParam('rootId', 'The ID of runs root folder.', model=Folder, force=True,
-                    destName='root', paramType='query')
+        .modelParam('taleId', 'The ID of a tale.', model=Tale, force=True, destName='tale',
+                    paramType='query')
         .param('name', 'Return the folder with this name or nothing if no such folder exists.',
                required=False, dataType='string')
         .errorResponse('Access was denied (if current user does not have read access to this '
                        'tale)', 403)
     )
-    def exists(self, root: dict, name: str):
-        return super().exists(root, name)
+    def exists(self, tale: dict, name: str):
+        return super().exists(tale, name)
 
     @access.user(TokenScope.DATA_READ)
     @autoDescribeRoute(
@@ -278,7 +278,7 @@ class Run(AbstractVRResource):
     @autoDescribeRoute(
         Description('Fakes a run. Slowly updates the status, adds text to stdout/stderr, and puts'
                     'files in the results dir.')
-        .modelParam('id', 'The ID of a run folder.', model=Folder, force=True,
+        .modelParam('id', 'The ID of a run.', model=Folder, force=True,
                     destName='rfolder')
         .errorResponse('Access was denied (if current user does not have write access to '
                        'this run)', 403)

--- a/server/resources/version.py
+++ b/server/resources/version.py
@@ -73,6 +73,7 @@ class Version(AbstractVRResource):
         return dataSet
 
     @access.user(TokenScope.DATA_READ)
+    @filtermodel("folder")
     @autoDescribeRoute(
         Description('Returns a version.')
         .modelParam('id', 'The ID of a version', model=Folder, force=True,

--- a/server/resources/version.py
+++ b/server/resources/version.py
@@ -29,41 +29,24 @@ class Version(AbstractVRResource):
     def __init__(self):
         super().__init__('version', Constants.VERSIONS_ROOT_DIR_NAME)
         self.route('GET', (':id', 'dataSet'), self.getDataset)
-        self.route('GET', ('latest',), self.getLatestVersion)
-
-    @access.user()
-    @autoDescribeRoute(
-        Description('Retrieves the versions root folder for this tale.')
-        .modelParam('taleId', 'The ID of a tale', model=Tale, force=True,
-                    paramType='query', destName='tale')
-        .errorResponse('Access was denied (if current user does not have read access to this '
-                       'tale)', 403)
-    )
-    def getRoot(self, tale: dict) -> dict:
-        # So we're overriding this because the description above has 'version' in it.
-        # This is also where we see the trouble with over-reliance on decorators: doesn't work
-        #   too well with inheritance.
-        # On the other hand, this could be solved by a modified decorator and some voodoo, but
-        # that's probably less maintainable than just copying and pasting descriptions
-        return super().getRoot(tale)
 
     @access.admin(TokenScope.DATA_WRITE)
     @autoDescribeRoute(
         Description('Clears all versions from a tale, but does not delete the respective '
                     'directories on disk. This is an administrative operation and should not be'
                     'used under normal circumstances.')
-        .modelParam('rootId', 'The ID of the versions root folder', model=Folder, force=True,
-                    destName='root', paramType='query')
+        .modelParam('taleId', 'The ID of the tale for which the versions should be cleared', model=Tale,
+               force=True, destName='tale', paramType='query')
     )
-    def clear(self, root: dict) -> None:
-        super().clear(root)
+    def clear(self, tale: dict) -> None:
+        super().clear(tale)
 
     @access.user(TokenScope.DATA_WRITE)
     @filtermodel('folder')
     @autoDescribeRoute(
-        Description('Rename a version associated with a tale. Returns the renamed version '
+        Description('Rename a version. Returns the renamed version '
                     'folder')
-        .modelParam('id', 'The ID of version folder', model=Folder, force=True,
+        .modelParam('id', 'The ID of version', model=Folder, force=True,
                     destName='vfolder')
         .param('newName', 'The new name', required=True, dataType='string')
         .errorResponse('Access was denied (if current user does not have write access to this '
@@ -75,9 +58,9 @@ class Version(AbstractVRResource):
 
     @access.user(TokenScope.DATA_READ)
     @autoDescribeRoute(
-        Description('Returns the dataset associated with a version folder, but with some additional'
+        Description('Returns the dataset associated with a version, but with some additional '
                     'entries such as the type of object (folder/item) and the object dictionaries.')
-        .modelParam('id', 'The ID of a version folder', model=Folder, force=True,
+        .modelParam('id', 'The ID of a version', model=Folder, force=True,
                     destName='vfolder')
         .errorResponse('Access was denied (if current user does not have read access to the '
                        'respective version folder.', 403)
@@ -90,8 +73,8 @@ class Version(AbstractVRResource):
 
     @access.user(TokenScope.DATA_READ)
     @autoDescribeRoute(
-        Description('Returns a version folder.')
-        .modelParam('id', 'The ID of a version folder', model=Folder, force=True,
+        Description('Returns a version.')
+        .modelParam('id', 'The ID of a version', model=Folder, force=True,
                     destName='vfolder')
         .errorResponse('Access was denied (if current user does not have read access to the '
                        'respective version folder.', 403)
@@ -165,40 +148,28 @@ class Version(AbstractVRResource):
     @access.user(TokenScope.DATA_READ)
     @filtermodel('folder')
     @autoDescribeRoute(
-        Description('Lists all versions.')
-        .modelParam('rootId', 'The ID of versions root folder.', model=Folder, force=True,
-                    destName='root', paramType='query')
+        Description('Lists versions.')
+        .modelParam('taleId', 'The ID of a tale for which versions are to be listed.',
+                    model=Tale, plugin='wholetale', force=True, destName='tale', paramType='query')
         .pagingParams(defaultSort='created')
         .errorResponse('Access was denied (if current user does not have read access to this tale)',
                        403)
     )
-    def list(self, root: dict, limit, offset, sort):
-        return super().list(root, limit, offset, sort)
+    def list(self, tale: dict, limit, offset, sort):
+        return super().list(tale, limit, offset, sort)
 
     @access.user(TokenScope.DATA_READ)
     @autoDescribeRoute(
-        Description('Check if a version exists.')
-        .modelParam('rootId', 'The ID of versions root folder.', model=Folder, force=True,
-                    destName='root', paramType='query')
+        Description('Check if a version with the given name exists.')
+        .modelParam('taleId', 'The ID of versions root folder.', model=Tale, force=True,
+                    destName='tale', paramType='query')
         .param('name', 'Return the folder with this name or nothing if no such folder exists.',
                required=False, dataType='string')
         .errorResponse('Access was denied (if current user does not have read access to this tale)',
                        403)
     )
-    def exists(self, root: dict, name: str):
-        return super().exists(root, name)
-
-    @access.user(TokenScope.DATA_READ)
-    @filtermodel('folder')
-    @autoDescribeRoute(
-        Description('Retrieves the latest version.')
-        .modelParam('rootId', 'The ID of versions root folder.', model=Folder, force=True,
-                    destName='root', paramType='query')
-        .errorResponse('Access was denied (if current user does not have read access to this tale)',
-                       403)
-    )
-    def getLatestVersion(self, root: dict) -> Optional[dict]:
-        return self._getLastVersion(root)
+    def exists(self, tale: dict, name: str):
+        return super().exists(tale, name)
 
     @classmethod
     def _incrementReferenceCount(cls, vfolder):


### PR DESCRIPTION
…ply using the tale as the logocal parent of a version/run.

The changes to the REST API are:
- removed getRoot (see above)
- GET /version/list -> GET /version
- GET /version/id/rename -> PUT /version/id
- same for GET /run/list and GET /run/id/rename
- removed GET /version/latest; the same can be achieved by a list (e.g., GET /version?sort=created&sortOrder=-1&limit=1)

There is a companion PR in girderfs (17)