### PR TITLE
Add an ability to restore a Tale from a Version

### DIFF
--- a/plugin_tests/versions_test.py
+++ b/plugin_tests/versions_test.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 import pathlib
@@ -75,6 +76,52 @@ class VersionTestCase(base.TestCase):
             ),
         )
 
+        self.image2 = Image().createImage(
+            name="test other name",
+            creator=self.user_one,
+            public=True,
+            config=dict(
+                template="base.tpl",
+                buildpack="OtherBuildPack",
+                user="someUser",
+                port=8888,
+                urlPath="",
+            ),
+        )
+
+        self.data_map = [
+            {
+                "dataId": "resource_map_doi:10.5065/D6862DM8",
+                "doi": "10.5065/D6862DM8",
+                "name": "Humans and Hydrology at High Latitudes: Water Use Information",
+                "repository": "DataONE",
+                "size": 28_856_295,
+                "tale": False,
+            },
+            {
+                "dataId": (
+                    "https://dataverse.harvard.edu/dataset.xhtml?"
+                    "persistentId=doi:10.7910/DVN/Q5PV4U"
+                ),
+                "doi": "doi:10.7910/DVN/Q5PV4U",
+                "name": (
+                    "Replication Data for: Misgovernance and Human Rights: "
+                    "The Case of Illegal Detention without Intent"
+                ),
+                "repository": "Dataverse",
+                "size": 6_326_512,
+                "tale": False,
+            },
+        ]
+
+        resp = self.request(
+            path="/dataset/register",
+            method="POST",
+            params={"dataMap": json.dumps(self.data_map)},
+            user=self.user_one,
+        )
+        self.assertStatusOk(resp)
+
     def _create_example_tale(self, dataset=None):
         if dataset is None:
             dataset = []
@@ -104,7 +151,10 @@ class VersionTestCase(base.TestCase):
             body=json.dumps(tale),
         )
         self.assertStatusOk(resp)
-        return resp.json
+        tale = resp.json
+        if "_accessLevel" not in resp.json:
+            tale = Tale().filter(tale, self.user_one)  # <- this is a bug
+        return tale
 
     def _remove_example_tale(self, tale, user=None):
         if not user:
@@ -117,7 +167,7 @@ class VersionTestCase(base.TestCase):
     def testBasicVersionOps(self):
         from girder.plugins.wt_versioning.constants import PluginSettings
 
-        tale = self._create_example_tale()
+        tale = self._create_example_tale(self.get_dataset([0]))
         workspace = Folder().load(tale["workspaceId"], force=True)
 
         file1_content = b"Hello World!"
@@ -166,12 +216,34 @@ class VersionTestCase(base.TestCase):
         with open(nested_file.as_posix(), "wb") as f:
             f.write(file2_content)
 
+        # Make some mods to Tale itself
+        first_version_tale = copy.deepcopy(tale)
+        tale = Tale().load(tale["_id"], force=True)
+        tale["dataSet"] = self.get_dataset([1])
+        tale["authors"].append(
+            {
+                "firstName": "Craig",
+                "lastName": "Willis",
+                "orcid": "https://orcid.org/0000-0002-6148-7196",
+            }
+        )
+        tale.update(
+            {
+                "category": "rocket science",
+                "config": {"foo": "bar"},
+                "description": "A better description",
+                "imageId": self.image2["_id"],
+                "title": "New better title",
+            }
+        )
+        tale = Tale().save(tale)
+
         # Try to create a 2nd version, but using old name (should fail)
         resp = self.request(
             path="/version",
             method="POST",
             user=self.user_one,
-            params={"name": "First Version", "taleId": tale["_id"]},
+            params={"name": "First Version", "taleId": str(tale["_id"])},
         )
         self.assertStatus(resp, 409)
         self.assertEqual(
@@ -253,6 +325,35 @@ class VersionTestCase(base.TestCase):
             },
         )
 
+        # Restore First Version
+        resp = self.request(
+            method="PUT",
+            user=self.user_one,
+            path=f"/tale/{tale['_id']}/restore",
+            params={"versionId": version["_id"]},
+        )
+        self.assertStatusOk(resp)
+        restored_tale = resp.json
+
+        for key in restored_tale.keys():
+            if key in (
+                "created",
+                "updated",
+            ):
+                continue
+            try:
+                self.assertEqual(restored_tale[key], first_version_tale[key])
+            except AssertionError:
+                print(key)
+                raise
+
+        workspace = Folder().load(restored_tale["workspaceId"], force=True)
+        workspace_path = pathlib.Path(workspace["fsPath"])
+        w_should_be_a_file = workspace_path / file1_name
+        self.assertTrue(w_should_be_a_file.is_file())
+        w_should_not_be_a_file = workspace_path / dir_name / file2_name
+        self.assertFalse(w_should_not_be_a_file.is_file())
+
         # Remove and see if it's gone
         resp = self.request(
             path=f"/version/{new_version['_id']}", method="DELETE", user=self.user_one
@@ -281,34 +382,20 @@ class VersionTestCase(base.TestCase):
         # Clean up
         self._remove_example_tale(tale)
 
-    def testDatasetHandling(self):
-        user_data_map = [
-            {
-                "dataId": "resource_map_doi:10.5065/D6862DM8",
-                "doi": "10.5065/D6862DM8",
-                "name": "Humans and Hydrology at High Latitudes: Water Use Information",
-                "repository": "DataONE",
-                "size": 28_856_295,
-            }
-        ]
-
-        resp = self.request(
-            path="/dataset/register",
-            method="POST",
-            params={"dataMap": json.dumps(user_data_map)},
-            user=self.user_one,
-        )
-        self.assertStatusOk(resp)
-
+    def get_dataset(self, indices):
         user = User().load(self.user_one["_id"], force=True)
-        dataset = [
-            {
-                "_modelType": "folder",
-                "itemId": str(user["myData"][0]),
-                "mountPath": user_data_map[0]["name"],
-            }
-        ]
-        tale = self._create_example_tale(dataset=dataset)
+        dataSet = []
+        for i in indices:
+            _id = user["myData"][i]
+            folder = Folder().load(_id, force=True)
+            dataSet.append(
+                {"_modelType": "folder", "itemId": str(_id), "mountPath": folder["name"]}
+            )
+        return dataSet
+
+    def testDatasetHandling(self):
+
+        tale = self._create_example_tale(dataset=self.get_dataset([0]))
         resp = self.request(
             path="/version",
             method="POST",
@@ -324,6 +411,6 @@ class VersionTestCase(base.TestCase):
         )
         self.assertStatusOk(resp)
         self.assertTrue(len(resp.json), 1)
-        self.assertEqual(resp.json[0]["itemId"], dataset[0]["itemId"])
+        self.assertEqual(resp.json[0]["itemId"], self.get_dataset([0])[0]["itemId"])
 
         self._remove_example_tale(tale)

--- a/plugin_tests/versions_test.py
+++ b/plugin_tests/versions_test.py
@@ -337,6 +337,7 @@ class VersionTestCase(base.TestCase):
             if key in (
                 "created",
                 "updated",
+                "restoredFrom",
             ):
                 continue
             try:

--- a/plugin_tests/versions_test.py
+++ b/plugin_tests/versions_test.py
@@ -373,7 +373,12 @@ class VersionTestCase(base.TestCase):
             path="/version",
             method="POST",
             user=self.user_one,
-            params={"name": "First Version", "taleId": tale["_id"], "allowRename": True},
+            params={
+                "name": "First Version",
+                "taleId": tale["_id"],
+                "allowRename": True,
+                "force": True
+            },
         )
         self.assertStatusOk(resp)
         self.assertEqual(resp.json["name"], "First Version (1)")

--- a/plugin_tests/versions_test.py
+++ b/plugin_tests/versions_test.py
@@ -152,8 +152,6 @@ class VersionTestCase(base.TestCase):
         )
         self.assertStatusOk(resp)
         tale = resp.json
-        if "_accessLevel" not in resp.json:
-            tale = Tale().filter(tale, self.user_one)  # <- this is a bug
         return tale
 
     def _remove_example_tale(self, tale, user=None):

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -72,5 +72,5 @@ def load(info):
     events.bind('model.tale.save.created', 'wt_versioning', addVersionsAndRuns)
     Tale().exposeFields(level=AccessType.READ, fields={"versionsRootId", "runsRootId"})
 
-    info['apiRoot'].version = Version()
+    info['apiRoot'].version = Version(info["apiRoot"].tale)
     info['apiRoot'].run = Run()

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -70,7 +70,9 @@ def load(info):
     resetCrashedCriticalSections()
 
     events.bind('model.tale.save.created', 'wt_versioning', addVersionsAndRuns)
-    Tale().exposeFields(level=AccessType.READ, fields={"versionsRootId", "runsRootId"})
+    Tale().exposeFields(
+        level=AccessType.READ, fields={"versionsRootId", "runsRootId", "restoredFrom"}
+    )
 
     info['apiRoot'].version = Version(info["apiRoot"].tale)
     info['apiRoot'].run = Run()

--- a/server/lib/util.py
+++ b/server/lib/util.py
@@ -1,9 +1,7 @@
 import pathlib
 
 from girder.models.setting import Setting
-from girder.plugins.wt_home_dir.lib.PathMapper import TalePathMapper
 from ..constants import PluginSettings
-from girder.plugins.wt_home_dir.constants import PluginSettings as WTHomesPluginSettings
 
 
 def getTaleVersionsDirPath(tale: dict) -> pathlib.Path:
@@ -12,13 +10,6 @@ def getTaleVersionsDirPath(tale: dict) -> pathlib.Path:
 
 def getTaleRunsDirPath(tale: dict) -> pathlib.Path:
     return getTaleDirPath(tale, PluginSettings.RUNS_DIRS_ROOT)
-
-
-def getTaleWorkspaceDirPath(tale: dict) -> pathlib.Path:
-    settings = Setting()
-    root = settings.get(WTHomesPluginSettings.TALE_DIRS_ROOT)
-    taleId = str(tale['_id'])
-    return pathlib.Path(root) / TalePathMapper().davToPhysical('/' + taleId)[1:]
 
 
 def getTaleDirPath(tale: dict, rootProp: str) -> pathlib.Path:

--- a/server/resources/abstract_resource.py
+++ b/server/resources/abstract_resource.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Tuple, Optional
+from typing import Optional
 
 import pathvalidate
 
@@ -62,22 +62,24 @@ class AbstractVRResource(Resource):
                 break
         return q["name"]
 
-    def _createSubdir(self, rootDir: Path, rootFolder: dict, name: str) -> Tuple[dict, Path]:
+    def _createSubdir(
+        self, rootDir: Path, rootFolder: dict, name: str, user=None
+    ) -> dict:
         """Create both Girder folder and corresponding directory. The name is stored in the Girder
         folder, whereas the name of the directory is taken from the folder ID. This is a
         deliberate step to discourage renaming of directories directly on disk, which would mess
         up the mapping between Girder folders and directories
         """
-        folder = Folder().createFolder(rootFolder, name, creator=self.getCurrentUser())
+        folder = Folder().createFolder(rootFolder, name, creator=user)
         dirname = str(folder['_id'])
         dir = rootDir / dirname
         dir.mkdir(parents=True)
         folder.update({'fsPath': dir.absolute().as_posix(), 'isMapping': True})
-        Folder().save(folder, validate=False, triggerEvents=False)
+        folder = Folder().save(folder, validate=False, triggerEvents=False)
 
         # update the time
         Folder().updateFolder(rootFolder)
-        return (folder, dir)
+        return folder
 
     def clear(self, tale: dict) -> None:
         user = self.getCurrentUser()

--- a/server/resources/run.py
+++ b/server/resources/run.py
@@ -244,7 +244,7 @@ class Run(AbstractVRResource):
         if not name:
             name = self._generateName()
 
-        (runFolder, runDir) = self._createSubdir(rootDir, root, name)
+        runFolder = self._createSubdir(rootDir, root, name, user=self.getCurrentUser())
 
         runFolder['runVersionId'] = version['_id']
         runFolder['runStatus'] = RunStatus.UNKNOWN.code
@@ -258,7 +258,7 @@ class Run(AbstractVRResource):
         #  .status
         #  .stdout (created using stream() above)
         #  .stderr (-''-)
-
+        runDir = Path(runFolder["fsPath"])
         (runDir / 'version').symlink_to('../../Versions/%s' % version['_id'], True)
         (runDir / 'data').symlink_to('version/data', True)
         (runDir / 'workspace').symlink_to('version/workspace', True)

--- a/server/resources/version.py
+++ b/server/resources/version.py
@@ -4,7 +4,7 @@ import os
 import shutil
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 import pymongo
 


### PR DESCRIPTION
### Rationale
This PR adds a couple of features:
1. Snapshots now store both `manifest.json` and `environment.json` in order to preserve non-file components of a Tale.
2. A tale can now be fully restored from a version, using `POST /version/:id/restore` (this is really bad choice of a route, so expect it to be move elsewhere)

### TODO
1. ~Cleanup~
2. ~Tests~
3. ~Decide on a proper route (`PUT /tale/:id/restore?versionId=...` ?)~
4. Tale should be snapshot before restore (potentially a separate PR)

### How to test/play with it?
1. Deploy using:
    1. ~whole-tale/deploy-dev@cleanup~
    2. wt_versioning this PR
    3. ~https://github.com/whole-tale/girder_wholetale/pull/444~
    4. (optional) https://github.com/whole-tale/ngx-dashboard/pull/134
1. Run `scripts/create_versioned_tale.py`
2. Navigate to dashboard and check out how the only tale looks like
3. Using swagger restore the tale to the "First Version" (or use the new and shiny https://github.com/whole-tale/ngx-dashboard/pull/134)
4. Refresh dashboard and check how the tale looks like now