### PR TITLE
Allow to modify 'name' during the version creation if obj already exists

### DIFF
--- a/plugin_tests/versions_test.py
+++ b/plugin_tests/versions_test.py
@@ -268,6 +268,16 @@ class VersionTestCase(base.TestCase):
             {"message": f"Invalid folder id ({new_version['_id']}).", "type": "rest"},
         )
 
+        # Test allow rename
+        resp = self.request(
+            path="/version",
+            method="POST",
+            user=self.user_one,
+            params={"name": "First Version", "taleId": tale["_id"], "allowRename": True},
+        )
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json["name"], "First Version (1)")
+
         # Clean up
         self._remove_example_tale(tale)
 

--- a/server/resources/abstract_resource.py
+++ b/server/resources/abstract_resource.py
@@ -94,12 +94,12 @@ class AbstractVRResource(Resource):
             logger.info('Directory not removed: %s' % path)
         return 'Deleted %s versions' % n
 
-    def rename(self, vrfolder: dict, newName: str) -> dict:
+    def rename(self, vrfolder: dict, newName: str, allow_rename: bool = False) -> dict:
         if not newName:
             raise RestException('New name cannot be empty.', code=400)
         user = self.getCurrentUser()
         root = Folder().load(vrfolder['parentId'], user=user, level=AccessType.WRITE)
-        self._checkNameSanity(newName, root)
+        newName = self._checkNameSanity(newName, root, allow_rename=allow_rename)
 
         vrfolder.update({'name': newName})
         return Folder().save(vrfolder)  # Filtering done by non abstract resource

--- a/server/resources/abstract_resource.py
+++ b/server/resources/abstract_resource.py
@@ -36,7 +36,12 @@ class AbstractVRResource(Resource):
             kwargs = dict(force=True)
         return Folder().load(tale[self.root_tale_field], exc=True, **kwargs)
 
-    def _checkNameSanity(self, name: Optional[str], parentFolder: dict) -> None:
+    def _checkNameSanity(
+        self,
+        name: Optional[str],
+        parentFolder: dict,
+        allow_rename: bool = False,
+    ) -> None:
         if not name:
             raise RestException('Name cannot be empty.', code=400)
 
@@ -45,8 +50,17 @@ class AbstractVRResource(Resource):
         except pathvalidate.ValidationError:
             raise RestException('Invalid file name: ' + name, code=400)
 
-        if Folder().findOne({'parentId': parentFolder['_id'], 'name': name}) is not None:
+        q = {'parentId': parentFolder['_id'], 'name': name}
+        if not allow_rename and Folder().findOne(q, fields=["_id"]):
             raise RestException('Name already exists: ' + name, code=409)
+
+        n = 0
+        while Folder().findOne(q, fields=["_id"]):
+            n += 1
+            q["name"] = f"{name} ({n})"
+            if n > 100:
+                break
+        return q["name"]
 
     def _createSubdir(self, rootDir: Path, rootFolder: dict, name: str) -> Tuple[dict, Path]:
         """Create both Girder folder and corresponding directory. The name is stored in the Girder

--- a/server/resources/version.py
+++ b/server/resources/version.py
@@ -51,13 +51,15 @@ class Version(AbstractVRResource):
         .modelParam('id', 'The ID of version', model=Folder, level=AccessType.WRITE,
                     destName='vfolder')
         .param('name', 'The new name', required=True, dataType='string')
+        .param('allowRename', 'Allow to modify "name" if object with the same name'
+               'already exists.', required=False, dataType='boolean', default=False)
         .errorResponse('Access was denied (if current user does not have write access to this '
                        'tale)', 403)
         .errorResponse('Illegal file name', 400)
         .errorResponse('Name already exists', 409)
     )
-    def rename(self, vfolder: dict, name: str) -> dict:
-        return super().rename(vfolder, name)
+    def rename(self, vfolder: dict, name: str, allowRename: bool) -> dict:
+        return super().rename(vfolder, name, allow_rename=allowRename)
 
     @access.user(TokenScope.DATA_READ)
     @autoDescribeRoute(


### PR DESCRIPTION
If `?allowRename=True` is passed to `POST /version` and the `name` is already used, a magical `(n)` will be appended to it, ensuring that the version name is unique. In every other situation the behavior is unchanged, i.e. `_checkName` should raise 409.