### PR TITLE
Create a new version when publishing and exporting

### DIFF
--- a/plugin_tests/versions_test.py
+++ b/plugin_tests/versions_test.py
@@ -430,23 +430,26 @@ class VersionTestCase(base.TestCase):
         self.assertStatusOk(resp)
         self.assertEqual(resp.json, [])
 
-        # Export the Tale. This should trigger the event to create the new version
-        resp = self.request(
-            path=f"/tale/{tale['_id']}/export",
-            method="GET",
-            user=self.user_one,
-            isJson=False,
-        )
-        self.assertStatusOk(resp)
+        # We're doing it twice to verify that only one version is created
+        # if there are no changes to the Tale.
+        for _ in range(2):
+            # Export the Tale. This should trigger the event to create the new version
+            resp = self.request(
+                path=f"/tale/{tale['_id']}/export",
+                method="GET",
+                user=self.user_one,
+                isJson=False,
+            )
+            self.assertStatusOk(resp)
 
-        # Get the versions for this Tale; there should only by a single one
-        # triggered by the export event
-        resp = self.request(
-            path="/version",
-            method="GET",
-            user=self.user_one,
-            params={"taleId": tale["_id"]},
-        )
-        self.assertStatusOk(resp)
-        self.assertTrue(len(resp.json), 1)
+            # Get the versions for this Tale; there should only by a single one
+            # triggered by the export event
+            resp = self.request(
+                path="/version",
+                method="GET",
+                user=self.user_one,
+                params={"taleId": tale["_id"]},
+            )
+            self.assertStatusOk(resp)
+            self.assertTrue(len(resp.json), 1)
         self._remove_example_tale(tale)

--- a/plugin_tests/versions_test.py
+++ b/plugin_tests/versions_test.py
@@ -420,6 +420,16 @@ class VersionTestCase(base.TestCase):
 
     def test_force_version(self):
         tale = self._create_example_tale(dataset=self.get_dataset([0]))
+        # Check that the tale has no versions.
+        resp = self.request(
+            path="/version",
+            method="GET",
+            user=self.user_one,
+            params={"taleId": tale["_id"]},
+        )
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, [])
+
         # Export the Tale. This should trigger the event to create the new version
         resp = self.request(
             path=f"/tale/{tale['_id']}/export",
@@ -428,6 +438,7 @@ class VersionTestCase(base.TestCase):
             isJson=False,
         )
         self.assertStatusOk(resp)
+
         # Get the versions for this Tale; there should only by a single one
         # triggered by the export event
         resp = self.request(

--- a/plugin_tests/versions_test.py
+++ b/plugin_tests/versions_test.py
@@ -334,11 +334,7 @@ class VersionTestCase(base.TestCase):
         restored_tale = resp.json
 
         for key in restored_tale.keys():
-            if key in (
-                "created",
-                "updated",
-                "restoredFrom",
-            ):
+            if key in ("created", "updated", "restoredFrom"):
                 continue
             try:
                 self.assertEqual(restored_tale[key], first_version_tale[key])
@@ -377,7 +373,7 @@ class VersionTestCase(base.TestCase):
                 "name": "First Version",
                 "taleId": tale["_id"],
                 "allowRename": True,
-                "force": True
+                "force": True,
             },
         )
         self.assertStatusOk(resp)
@@ -393,12 +389,15 @@ class VersionTestCase(base.TestCase):
             _id = user["myData"][i]
             folder = Folder().load(_id, force=True)
             dataSet.append(
-                {"_modelType": "folder", "itemId": str(_id), "mountPath": folder["name"]}
+                {
+                    "_modelType": "folder",
+                    "itemId": str(_id),
+                    "mountPath": folder["name"],
+                }
             )
         return dataSet
 
     def testDatasetHandling(self):
-
         tale = self._create_example_tale(dataset=self.get_dataset([0]))
         resp = self.request(
             path="/version",
@@ -420,15 +419,15 @@ class VersionTestCase(base.TestCase):
         self._remove_example_tale(tale)
 
     def test_force_version(self):
-
         tale = self._create_example_tale(dataset=self.get_dataset([0]))
         # Export the Tale. This should trigger the event to create the new version
         resp = self.request(
-            path="/export",
+            path=f"/tale/{tale['_id']}/export",
             method="GET",
             user=self.user_one,
-            params={"id": tale["_id"]},
+            isJson=False,
         )
+        self.assertStatusOk(resp)
         # Get the versions for this Tale; there should only by a single one
         # triggered by the export event
         resp = self.request(
@@ -439,3 +438,4 @@ class VersionTestCase(base.TestCase):
         )
         self.assertStatusOk(resp)
         self.assertTrue(len(resp.json), 1)
+        self._remove_example_tale(tale)

--- a/plugin_tests/versions_test.py
+++ b/plugin_tests/versions_test.py
@@ -418,3 +418,24 @@ class VersionTestCase(base.TestCase):
         self.assertEqual(resp.json[0]["itemId"], self.get_dataset([0])[0]["itemId"])
 
         self._remove_example_tale(tale)
+
+    def test_force_version(self):
+
+        tale = self._create_example_tale(dataset=self.get_dataset([0]))
+        # Export the Tale. This should trigger the event to create the new version
+        resp = self.request(
+            path="/export",
+            method="GET",
+            user=self.user_one,
+            params={"id": tale["_id"]},
+        )
+        # Get the versions for this Tale; there should only by a single one
+        # triggered by the export event
+        resp = self.request(
+            path="/version",
+            method="GET",
+            user=self.user_one,
+            params={"taleId": tale["_id"]},
+        )
+        self.assertStatusOk(resp)
+        self.assertTrue(len(resp.json), 1)

--- a/server/resources/version.py
+++ b/server/resources/version.py
@@ -375,7 +375,7 @@ class Version(AbstractVRResource):
         is the case if files are only modified through the WebDAV FS mounted in a tale container).
         """
         new_version_path = Path(new_version["fsPath"])
-        manifest = Manifest(tale, user, version_id=new_version["_id"], expand_folders=False)
+        manifest = Manifest(tale, user, versionId=new_version["_id"], expand_folders=False)
         with open((new_version_path / "manifest.json").as_posix(), "w") as fp:
             fp.write(manifest.dump_manifest())
 


### PR DESCRIPTION
When Tales are exported and published, they need to have versions. This PR calls `force_version` whenever an export or publish event happens and creates a version if one doesn't already exist.

Just realized the tests are a bit wonky here because they need to rely on the girder_wholetale branch