### PR TITLE
Update Tale/manifest whenever version changes. Fixes #22

### DIFF
--- a/server/resources/abstract_resource.py
+++ b/server/resources/abstract_resource.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import Optional
 
@@ -97,14 +98,15 @@ class AbstractVRResource(Resource):
         return 'Deleted %s versions' % n
 
     def rename(self, vrfolder: dict, newName: str, allow_rename: bool = False) -> dict:
+        user = self.getCurrentUser()
         if not newName:
             raise RestException('New name cannot be empty.', code=400)
-        user = self.getCurrentUser()
         root = Folder().load(vrfolder['parentId'], user=user, level=AccessType.WRITE)
         newName = self._checkNameSanity(newName, root, allow_rename=allow_rename)
-
         vrfolder.update({'name': newName})
-        return Folder().save(vrfolder)  # Filtering done by non abstract resource
+        os.utime(vrfolder["fsPath"])
+        os.utime(os.path.dirname(vrfolder["fsPath"]))
+        return Folder().updateFolder(vrfolder)  # Filtering done by non abstract resource
 
     def load(self, vrfolder: dict) -> dict:
         raise NotImplementedError


### PR DESCRIPTION
This PR updates the content of manifest whenever `PUT /version/:id` is called. Additionally it updates the Tale object whenever the content of version root folder changes (that includes creation, update and remove), which works around https://github.com/whole-tale/girderfs/issues/14.