### PR TITLE
Include versions while copying Tales. Fixes girder_wholetale#436

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,27 +15,19 @@ jobs:
       - run:
           name: Install Test Dependencies
           environment:
-            - CMAKE_SHORT_VERSION: "3.4"
-            - CMAKE_VERSION: "3.4.3"
             - LC_ALL: "C.UTF-8"
           command: |
-            curl -OL "http://cmake.org/files/v${CMAKE_SHORT_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz"
-            tar -x -C /usr --strip-components 1 -f "cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz"
-            git clone https://github.com/whole-tale/girder /tmp/girder
-            set -o pipefail; cd /tmp/girder ; python3 -m pip install -r requirements-dev.txt -e .[plugins,sftp] | cat
-            set -o pipefail; cd /tmp/girder/pytest_girder ; python3 -m pip install . | cat
-            cp /tmp/girder/CMakeLists.txt /girder/
-            cp /tmp/girder/.coveragerc /girder/
-            cp -r /tmp/girder/tests /girder/
+            set -o pipefail; cd /girder ; python3 -m pip install -r requirements-dev.txt -e .[plugins,sftp] | cat
+            set -o pipefail; cd /girder/pytest_girder ; python3 -m pip install . | cat
             cp /root/project/setup.cfg /girder/
       - run:
           name: Running Tests
           environment:
-            - PYTHON_VERSION: "3.7"
-            - COVERAGE_EXECUTABLE: "/usr/local/bin/coverage"
-            - FLAKE8_EXECUTABLE: "/usr/local/bin/flake8"
-            - VIRTUALENV_EXECUTABLE: "/usr/local/bin/virtualenv"
-            - PYTHON_EXECUTABLE: "/usr/bin/python3"
+            - PYTHON_VERSION: "3.9"
+            - COVERAGE_EXECUTABLE: "/girder/venv/bin/coverage"
+            - FLAKE8_EXECUTABLE: "/girder/venv/bin/flake8"
+            - VIRTUALENV_EXECUTABLE: "/girder/venv/bin/virtualenv"
+            - PYTHON_EXECUTABLE: "/girder/venv/bin/python3"
             - TEST_GROUP: "python"
           command: |
             mkdir /girder/build


### PR DESCRIPTION
Whenever a Tale is copied we now copy its versions too.

### How to test?
1. Depends on https://github.com/whole-tale/girder/pull/10 and https://github.com/whole-tale/girder_wholetale/pull/456
1. In deploy-dev: `sed -i scripts/create_versioned_tale.py -e "/public/ s/False/True/"`
2. Create a versioned tale using `create_versioned_tale.py` as **not** you.
3. Using Dashboard go to Public Tales.
4. Try to copy&run the Tale
5. Confirm versions are copied to your tale and that manifest.json in each of them matches the proper versionId.