### PR TITLE
Update /run endpoints

### DIFF
--- a/plugin.cmake
+++ b/plugin.cmake
@@ -5,6 +5,11 @@ add_python_test(
   PLUGIN ${PLUGIN}
 )
 
+add_python_test(
+  runs
+  PLUGIN ${PLUGIN}
+)
+
 add_python_style_test(
   python_static_analysis_${PLUGIN}
   "${PROJECT_SOURCE_DIR}/plugins/${PLUGIN}/server"

--- a/plugin_tests/runs_test.py
+++ b/plugin_tests/runs_test.py
@@ -129,6 +129,29 @@ class RunsTestCase(BaseTestCase):
         self.assertStatusOk(resp)
         self.assertEqual(resp.json, dict(status=2, statusString="RUNNING"))
 
+        # Create a 2nd tale to verify GET /run is doing the right thing...
+        tale2 = self._create_example_tale(self.get_dataset([0]))
+        self.assertNotEqual(tale["_id"], tale2["_id"])
+
+        resp = self.request(
+            path="/run",
+            method="GET",
+            user=self.user_one,
+            params={"taleId": tale2["_id"]},
+        )
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, [])  # This tale doesn't have runs
+
+        resp = self.request(
+            path="/run",
+            method="GET",
+            user=self.user_one,
+            params={"taleId": tale["_id"]},
+        )
+        self.assertStatusOk(resp)
+        self.assertTrue(len(resp.json), 1)
+        self.assertEqual(resp.json[0]["_id"], str(run["_id"]))
+
         resp = self.request(
             path=f"/run/{run['_id']}", method="DELETE", user=self.user_one
         )

--- a/plugin_tests/runs_test.py
+++ b/plugin_tests/runs_test.py
@@ -1,0 +1,124 @@
+import os
+
+from girder.models.folder import Folder
+from tests import base
+
+from .utils import BaseTestCase
+
+Image = None
+Tale = None
+TaleStatus = None
+
+
+def setUpModule():
+    base.enabledPlugins.append("virtual_resources")
+    base.enabledPlugins.append("wholetale")
+    base.enabledPlugins.append("wt_home_dir")
+    base.enabledPlugins.append("wt_versioning")
+    base.startServer()
+
+    global Tale, TaleStatus
+    from girder.plugins.wholetale.constants import TaleStatus
+    from girder.plugins.wholetale.models.tale import Tale
+
+
+def tearDownModule():
+    base.stopServer()
+
+
+class RunsTestCase(BaseTestCase):
+    def testBasicRunsOps(self):
+        tale = self._create_example_tale(self.get_dataset([0]))
+        workspace = Folder().load(tale["workspaceId"], force=True)
+
+        file1_content = b"Hello World!"
+        file1_name = "test_file.txt"
+
+        with open(os.path.join(workspace["fsPath"], file1_name), "wb") as f:
+            f.write(file1_content)
+
+        resp = self.request(
+            path="/version",
+            method="POST",
+            user=self.user_one,
+            params={"name": "First Version", "taleId": tale["_id"]},
+        )
+        self.assertStatusOk(resp)
+        version = resp.json
+
+        resp = self.request(
+            path="/run",
+            method="POST",
+            user=self.user_one,
+            params={"versionId": version["_id"], "name": "test run"},
+        )
+        self.assertStatusOk(resp)
+        run = resp.json
+
+        resp = self.request(path=f"/run/{run['_id']}", method="GET", user=self.user_one)
+        self.assertStatusOk(resp)
+        refreshed_run = resp.json
+        for key in ("created", "updated"):
+            run.pop(key)
+            refreshed_run.pop(key)
+        self.assertEqual(refreshed_run, run)
+
+        run = Folder().load(run["_id"], force=True)  # Need fsPath
+        self.assertTrue(
+            os.path.isfile(os.path.join(run["fsPath"], "workspace", file1_name))
+        )
+
+        # Try to delete version with an existing run.
+        # It should fail.
+        resp = self.request(
+            path=f"/version/{version['_id']}", method="DELETE", user=self.user_one
+        )
+        self.assertStatus(resp, 461)
+
+        # Rename run
+        resp = self.request(
+            path=f"/run/{run['_id']}",
+            method="PUT",
+            params={"name": "a better name"},
+            user=self.user_one,
+        )
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json["name"], "a better name")
+        run = Folder().load(run["_id"], force=True)
+        self.assertEqual(run["name"], resp.json["name"])
+
+        # Get current status, should be UNKNOWN
+        resp = self.request(
+            path=f"/run/{run['_id']}/status", method="GET", user=self.user_one
+        )
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, dict(status=0, statusString="UNKNOWN"))
+
+        # Set status to RUNNING
+        resp = self.request(
+            path=f"/run/{run['_id']}/status",
+            method="PATCH",
+            user=self.user_one,
+            params={"status": 2},
+        )
+        self.assertStatusOk(resp)
+
+        # Get current status, should be RUNNING
+        resp = self.request(
+            path=f"/run/{run['_id']}/status", method="GET", user=self.user_one
+        )
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, dict(status=2, statusString="RUNNING"))
+
+        resp = self.request(
+            path=f"/run/{run['_id']}", method="DELETE", user=self.user_one
+        )
+        self.assertFalse(
+            os.path.exists(os.path.join(run["fsPath"], "workspace", file1_name))
+        )
+        self.assertStatusOk(resp)
+
+        resp = self.request(
+            path=f"/version/{version['_id']}", method="DELETE", user=self.user_one
+        )
+        self.assertStatusOk(resp)

--- a/plugin_tests/runs_test.py
+++ b/plugin_tests/runs_test.py
@@ -87,6 +87,25 @@ class RunsTestCase(BaseTestCase):
         run = Folder().load(run["_id"], force=True)
         self.assertEqual(run["name"], resp.json["name"])
 
+        resp = self.request(
+            path="/run/exists",
+            method="GET",
+            params={"name": "test run", "taleId": tale["_id"]},
+            user=self.user_one,
+        )
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, {"exists": False})
+
+        resp = self.request(
+            path="/run/exists",
+            method="GET",
+            params={"name": "a better name", "taleId": tale["_id"]},
+            user=self.user_one,
+        )
+        self.assertStatusOk(resp)
+        self.assertTrue(resp.json["exists"])
+        self.assertEqual(resp.json["obj"]["_id"], str(run["_id"]))
+
         # Get current status, should be UNKNOWN
         resp = self.request(
             path=f"/run/{run['_id']}/status", method="GET", user=self.user_one

--- a/plugin_tests/utils.py
+++ b/plugin_tests/utils.py
@@ -1,0 +1,173 @@
+import json
+import shutil
+from pathlib import Path
+
+from girder.models.folder import Folder
+from girder.models.setting import Setting
+from girder.models.user import User
+from tests import base
+
+
+class BaseTestCase(base.TestCase):
+    def setUp(self):
+        from girder.plugins.wholetale.models.image import Image
+        from girder.plugins.wt_versioning.constants import PluginSettings
+
+        super(BaseTestCase, self).setUp()
+
+        asset_root = Path(self.assetstore["root"])
+        self.versions_root = asset_root / "versions"
+        self.versions_root.mkdir()
+        Setting().set(PluginSettings.VERSIONS_DIRS_ROOT, self.versions_root.as_posix())
+        self.runs_root = asset_root / "runs"
+        self.runs_root.mkdir()
+        Setting().set(PluginSettings.RUNS_DIRS_ROOT, self.runs_root.as_posix())
+
+        users = (
+            {
+                "email": "root@dev.null",
+                "login": "admin",
+                "firstName": "Root",
+                "lastName": "van Klompf",
+                "password": "secret",
+                "admin": True,
+            },
+            {
+                "email": "joe@dev.null",
+                "admin": False,
+                "login": "joeregular",
+                "firstName": "Joe",
+                "lastName": "Regular",
+                "password": "secret",
+            },
+            {
+                "firstName": "Barbara",
+                "lastName": "Smith",
+                "login": "basia",
+                "email": "basia@localhost.com",
+                "admin": False,
+                "password": "password",
+            },
+        )
+
+        self.admin, self.user_one, self.user_two = (
+            User().createUser(**user) for user in users
+        )
+        self.image = Image().createImage(
+            name="test my name",
+            creator=self.user_one,
+            public=True,
+            config=dict(
+                template="base.tpl",
+                buildpack="SomeBuildPack",
+                user="someUser",
+                port=8888,
+                urlPath="",
+            ),
+        )
+
+        self.image2 = Image().createImage(
+            name="test other name",
+            creator=self.user_one,
+            public=True,
+            config=dict(
+                template="base.tpl",
+                buildpack="OtherBuildPack",
+                user="someUser",
+                port=8888,
+                urlPath="",
+            ),
+        )
+
+        self.data_map = [
+            {
+                "dataId": "resource_map_doi:10.5065/D6862DM8",
+                "doi": "10.5065/D6862DM8",
+                "name": "Humans and Hydrology at High Latitudes: Water Use Information",
+                "repository": "DataONE",
+                "size": 28_856_295,
+                "tale": False,
+            },
+            {
+                "dataId": (
+                    "https://dataverse.harvard.edu/dataset.xhtml?"
+                    "persistentId=doi:10.7910/DVN/Q5PV4U"
+                ),
+                "doi": "doi:10.7910/DVN/Q5PV4U",
+                "name": (
+                    "Replication Data for: Misgovernance and Human Rights: "
+                    "The Case of Illegal Detention without Intent"
+                ),
+                "repository": "Dataverse",
+                "size": 6_326_512,
+                "tale": False,
+            },
+        ]
+
+        resp = self.request(
+            path="/dataset/register",
+            method="POST",
+            params={"dataMap": json.dumps(self.data_map)},
+            user=self.user_one,
+        )
+        self.assertStatusOk(resp)
+
+    def _create_example_tale(self, dataset=None):
+        if dataset is None:
+            dataset = []
+        tale = {
+            "authors": [
+                {
+                    "firstName": "Kacper",
+                    "lastName": "Kowalik",
+                    "orcid": "https://orcid.org/0000-0003-1709-3744",
+                }
+            ],
+            "category": "science",
+            "config": {},
+            "dataSet": dataset,
+            "description": "Something something...",
+            "imageId": str(self.image["_id"]),
+            "public": False,
+            "published": False,
+            "title": "Some tale with dataset and versions",
+        }
+
+        resp = self.request(
+            path="/tale",
+            method="POST",
+            user=self.user_one,
+            type="application/json",
+            body=json.dumps(tale),
+        )
+        self.assertStatusOk(resp)
+        tale = resp.json
+        return tale
+
+    def _remove_example_tale(self, tale, user=None):
+        if not user:
+            user = self.user_one
+        resp = self.request(
+            path="/tale/{_id}".format(**tale), method="DELETE", user=user
+        )
+        self.assertStatusOk(resp)
+
+    def get_dataset(self, indices):
+        user = User().load(self.user_one["_id"], force=True)
+        dataSet = []
+        for i in indices:
+            _id = user["myData"][i]
+            folder = Folder().load(_id, force=True)
+            dataSet.append(
+                {
+                    "_modelType": "folder",
+                    "itemId": str(_id),
+                    "mountPath": folder["name"],
+                }
+            )
+        return dataSet
+
+    def tearDown(self):
+        shutil.rmtree(self.runs_root)
+        shutil.rmtree(self.versions_root)
+        super().tearDown()

--- a/plugin_tests/versions_test.py
+++ b/plugin_tests/versions_test.py
@@ -47,6 +47,15 @@ class VersionTestCase(BaseTestCase):
             f.write(file1_content)
 
         resp = self.request(
+            path="/version/exists",
+            method="GET",
+            user=self.user_one,
+            params={"name": "First Version", "taleId": tale["_id"]},
+        )
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, {"exists": False})
+
+        resp = self.request(
             path="/version",
             method="POST",
             user=self.user_one,
@@ -54,6 +63,16 @@ class VersionTestCase(BaseTestCase):
         )
         self.assertStatusOk(resp)
         version = resp.json
+
+        resp = self.request(
+            path="/version/exists",
+            method="GET",
+            user=self.user_one,
+            params={"name": "First Version", "taleId": tale["_id"]},
+        )
+        self.assertStatusOk(resp)
+        self.assertTrue(resp.json["exists"])
+        self.assertEqual(resp.json["obj"]["_id"], version["_id"])
 
         version_root = Setting().get(PluginSettings.VERSIONS_DIRS_ROOT)
         version_path = pathlib.Path(version_root) / tale["_id"][:2] / tale["_id"]

--- a/plugin_tests/versions_test.py
+++ b/plugin_tests/versions_test.py
@@ -3,14 +3,13 @@ import json
 import os
 import pathlib
 import time
+
 from girder.models.folder import Folder
 from girder.models.setting import Setting
-from girder.models.user import User
-
 from tests import base
 
+from .utils import BaseTestCase
 
-Image = None
 Tale = None
 TaleStatus = None
 
@@ -22,149 +21,16 @@ def setUpModule():
     base.enabledPlugins.append("wt_versioning")
     base.startServer()
 
-    global Image, Tale, TaleStatus
-    from girder.plugins.wholetale.models.image import Image
-    from girder.plugins.wholetale.models.tale import Tale
+    global Tale, TaleStatus
     from girder.plugins.wholetale.constants import TaleStatus
+    from girder.plugins.wholetale.models.tale import Tale
 
 
 def tearDownModule():
     base.stopServer()
 
 
-class VersionTestCase(base.TestCase):
-    def setUp(self):
-        super(VersionTestCase, self).setUp()
-
-        users = (
-            {
-                "email": "root@dev.null",
-                "login": "admin",
-                "firstName": "Root",
-                "lastName": "van Klompf",
-                "password": "secret",
-                "admin": True,
-            },
-            {
-                "email": "joe@dev.null",
-                "admin": False,
-                "login": "joeregular",
-                "firstName": "Joe",
-                "lastName": "Regular",
-                "password": "secret",
-            },
-            {
-                "firstName": "Barbara",
-                "lastName": "Smith",
-                "login": "basia",
-                "email": "basia@localhost.com",
-                "admin": False,
-                "password": "password",
-            },
-        )
-
-        self.admin, self.user_one, self.user_two = (
-            User().createUser(**user) for user in users
-        )
-        self.image = Image().createImage(
-            name="test my name",
-            creator=self.user_one,
-            public=True,
-            config=dict(
-                template="base.tpl",
-                buildpack="SomeBuildPack",
-                user="someUser",
-                port=8888,
-                urlPath="",
-            ),
-        )
-
-        self.image2 = Image().createImage(
-            name="test other name",
-            creator=self.user_one,
-            public=True,
-            config=dict(
-                template="base.tpl",
-                buildpack="OtherBuildPack",
-                user="someUser",
-                port=8888,
-                urlPath="",
-            ),
-        )
-
-        self.data_map = [
-            {
-                "dataId": "resource_map_doi:10.5065/D6862DM8",
-                "doi": "10.5065/D6862DM8",
-                "name": "Humans and Hydrology at High Latitudes: Water Use Information",
-                "repository": "DataONE",
-                "size": 28_856_295,
-                "tale": False,
-            },
-            {
-                "dataId": (
-                    "https://dataverse.harvard.edu/dataset.xhtml?"
-                    "persistentId=doi:10.7910/DVN/Q5PV4U"
-                ),
-                "doi": "doi:10.7910/DVN/Q5PV4U",
-                "name": (
-                    "Replication Data for: Misgovernance and Human Rights: "
-                    "The Case of Illegal Detention without Intent"
-                ),
-                "repository": "Dataverse",
-                "size": 6_326_512,
-                "tale": False,
-            },
-        ]
-
-        resp = self.request(
-            path="/dataset/register",
-            method="POST",
-            params={"dataMap": json.dumps(self.data_map)},
-            user=self.user_one,
-        )
-        self.assertStatusOk(resp)
-
-    def _create_example_tale(self, dataset=None):
-        if dataset is None:
-            dataset = []
-        tale = {
-            "authors": [
-                {
-                    "firstName": "Kacper",
-                    "lastName": "Kowalik",
-                    "orcid": "https://orcid.org/0000-0003-1709-3744",
-                }
-            ],
-            "category": "science",
-            "config": {},
-            "dataSet": dataset,
-            "description": "Something something...",
-            "imageId": str(self.image["_id"]),
-            "public": False,
-            "published": False,
-            "title": "Some tale with dataset and versions",
-        }
-
-        resp = self.request(
-            path="/tale",
-            method="POST",
-            user=self.user_one,
-            type="application/json",
-            body=json.dumps(tale),
-        )
-        self.assertStatusOk(resp)
-        tale = resp.json
-        return tale
-
-    def _remove_example_tale(self, tale, user=None):
-        if not user:
-            user = self.user_one
-        resp = self.request(
-            path="/tale/{_id}".format(**tale), method="DELETE", user=user
-        )
-        self.assertStatusOk(resp)
-
+class VersionTestCase(BaseTestCase):
     def testBasicVersionOps(self):
         from girder.plugins.wt_versioning.constants import PluginSettings
 
@@ -431,21 +297,6 @@ class VersionTestCase(base.TestCase):
 
         # Clean up
         self._remove_example_tale(tale)
-
-    def get_dataset(self, indices):
-        user = User().load(self.user_one["_id"], force=True)
-        dataSet = []
-        for i in indices:
-            _id = user["myData"][i]
-            folder = Folder().load(_id, force=True)
-            dataSet.append(
-                {
-                    "_modelType": "folder",
-                    "itemId": str(_id),
-                    "mountPath": folder["name"],
-                }
-            )
-        return dataSet
 
     def testDatasetHandling(self):
         tale = self._create_example_tale(dataset=self.get_dataset([0]))

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -131,6 +131,9 @@ def load(info):
     Tale().exposeFields(
         level=AccessType.READ, fields={"versionsRootId", "runsRootId", "restoredFrom"}
     )
+    Folder().exposeFields(
+        level=AccessType.READ, fields={"runVersionId", "runStatus"}
+    )
 
     info['apiRoot'].version = Version(info["apiRoot"].tale)
     info['apiRoot'].run = Run()

--- a/server/resources/abstract_resource.py
+++ b/server/resources/abstract_resource.py
@@ -19,7 +19,6 @@ class AbstractVRResource(Resource):
         Resource.__init__(self)
         self.resourceName = resourceName
         self.rootDirName = rootDirName
-        self.route('GET', ('clear',), self.clear)
         self.route('POST', (), self.create)
         self.route('GET', (), self.list)
         self.route('GET', ('exists',), self.exists)
@@ -82,21 +81,6 @@ class AbstractVRResource(Resource):
         # update the time
         Folder().updateFolder(rootFolder)
         return folder
-
-    def clear(self, tale: dict) -> None:
-        user = self.getCurrentUser()
-        root = self._getRootFromTale(tale, user=user, level=AccessType.ADMIN)
-        n = 0
-        for v in Folder().childFolders(root, "folder", user=user, level=AccessType.ADMIN):
-            n += 1
-            if 'fsPath' in v:
-                path = v['fsPath']
-            else:
-                path = 'Unknown'
-                logger.warn('Missing fspath: %s' % v)
-            Folder().remove(v)
-            logger.info('Directory not removed: %s' % path)
-        return 'Deleted %s versions' % n
 
     def rename(self, vrfolder: dict, newName: str, allow_rename: bool = False) -> dict:
         user = self.getCurrentUser()

--- a/server/resources/run.py
+++ b/server/resources/run.py
@@ -127,7 +127,9 @@ class Run(AbstractVRResource):
                        'tale)', 403)
     )
     def list(self, tale: dict, limit, offset, sort):
-        return super().list(tale, limit, offset, sort)
+        return super().list(
+            tale, user=self.getCurrentUser(), limit=limit, offset=offset, sort=sort
+        )
 
     @access.user(TokenScope.DATA_READ)
     @autoDescribeRoute(

--- a/server/resources/run.py
+++ b/server/resources/run.py
@@ -121,7 +121,7 @@ class Run(AbstractVRResource):
     @autoDescribeRoute(
         Description('Lists runs.')
         .modelParam('taleId', 'The ID of the tale to which the runs belong.', model=Tale,
-                    level=AccessType.READ, destName='tale')
+                    level=AccessType.READ, destName='tale', paramType="query")
         .pagingParams(defaultSort='created')
         .errorResponse('Access was denied (if current user does not have read access to this '
                        'tale)', 403)

--- a/server/resources/run.py
+++ b/server/resources/run.py
@@ -1,15 +1,8 @@
-import math
-import random
 import shutil
-import time as t
 from datetime import datetime
 from pathlib import Path
-from threading import Thread
 from typing import Union, Optional
 
-import cherrypy
-
-from girder import logger
 from girder.api import access
 from girder.api.describe import autoDescribeRoute, Description
 from girder.api.rest import filtermodel
@@ -31,10 +24,8 @@ class Run(AbstractVRResource):
 
     def __init__(self):
         super().__init__('run', Constants.RUNS_ROOT_DIR_NAME)
-        self.route('PATCH', (':id', 'stream'), self.stream)
         self.route('PATCH', (':id', 'status'), self.setStatus)
         self.route('GET', (':id', 'status'), self.status)
-        self.route('GET', (':id', 'fakeAnActualRun'), self.fakeAnActualRun)
 
     @access.user()
     @filtermodel('folder')
@@ -47,17 +38,6 @@ class Run(AbstractVRResource):
     )
     def getRoot(self, tale: dict) -> dict:
         return super().getRoot(tale)
-
-    @access.user
-    @autoDescribeRoute(
-        Description('Clears all runs from a tale, but does not delete the respective '
-                    'directories on disk. This is an administrative operation and should not be'
-                    'used under normal circumstances.')
-        .modelParam('taleId', 'The ID of the runs root folder', model=Tale, level=AccessType.ADMIN,
-                    destName='tale', paramType='query')
-    )
-    def clear(self, tale: dict) -> None:
-        super().clear(tale)
 
     @access.user(TokenScope.DATA_WRITE)
     @filtermodel('folder')
@@ -74,6 +54,7 @@ class Run(AbstractVRResource):
         return super().rename(rfolder, name)
 
     @access.user(TokenScope.DATA_READ)
+    @filtermodel('folder')
     @autoDescribeRoute(
         Description('Returns a run.')
         .modelParam('id', 'The ID of a run.', model=Folder, level=AccessType.READ,
@@ -128,7 +109,7 @@ class Run(AbstractVRResource):
         trashDir = path.parent / '.trash'
 
         version = Folder().load(
-            rfolder['runVersionId'], level=AccessType.WRTITE, user=self.getCurrentUser()
+            rfolder['runVersionId'], level=AccessType.WRITE, user=self.getCurrentUser()
         )
 
         Folder().remove(rfolder)
@@ -204,42 +185,6 @@ class Run(AbstractVRResource):
         runDir = Path(rfolder['fsPath'])
         self._write_status(runDir, _status)
 
-    @access.user(TokenScope.DATA_WRITE)
-    @autoDescribeRoute(
-        Description('Appends data to the .stdout and .stderr files. One of stdoutData and '
-                    'stderrData parameters is required.')
-        .modelParam('id', 'The ID of a run.', model=Folder,
-                    level=AccessType.WRITE, destName='rfolder')
-        .param('stdoutData', 'Data to append to .stdout', dataType='string', required=False)
-        .param('stderrData', 'Data to append to .stderr', dataType='string', required=False)
-        .errorResponse('Access was denied (if current user does not have read access to '
-                       'this run)', 403)
-    )
-    def stream(self, rfolder: dict, stdoutData: str = None, stderrData: str = None) -> None:
-        self._stream(rfolder, stdoutData, stderrData)
-
-    def _stream(self, rfolder: dict, stdoutData: str = None, stderrData: str = None) -> None:
-        runDir = Path(rfolder['fsPath'])
-        new = False
-        if stdoutData is not None:
-            new |= self._append(runDir, '.stdout', stdoutData)
-        if stderrData is not None:
-            new |= self._append(runDir, '.stderr', stderrData)
-        if new:
-            # Girder does not change the 'updated' attribute on a parent folder when a child
-            # is added. This is a bit different here, since runDir is the root of a virtual object
-            # hierarchy and, while there is an actual folder on disk corresponding to it, which
-            # does have a proper modified/updated time, this does not get 'propagated' to the
-            # girder object, so we manually set the updated field when a new file appears.
-            Folder().updateFolder(rfolder)
-
-    def _append(self, dir: Path, filename: str, data: str):
-        file = dir / filename
-        new = not file.exists()
-        with open(file.as_posix(), 'a') as f:
-            f.write(data)
-        return new
-
     def _create(self, version: dict, name: Optional[str], root: dict, rootDir: Path) -> dict:
         if not name:
             name = self._generateName()
@@ -283,41 +228,3 @@ class Run(AbstractVRResource):
     def _generateName(self):
         now = datetime.now()
         return now.strftime(RUN_NAME_FORMAT)
-
-    @access.user()
-    @filtermodel('folder')
-    @autoDescribeRoute(
-        Description('Fakes a run. Slowly updates the status, adds text to stdout/stderr, and puts'
-                    'files in the results dir.')
-        .modelParam('id', 'The ID of a run.', model=Folder, level=AccessType.WRITE,
-                    destName='rfolder')
-        .errorResponse('Access was denied (if current user does not have write access to '
-                       'this run)', 403)
-    )
-    def fakeAnActualRun(self, rfolder: dict) -> None:
-        t = Thread(target=self._fakeRun, args=(rfolder, self.getCurrentToken()))
-        t.start()
-
-    def _fakeRun(self, rfolder: dict, token: dict) -> None:
-        cherrypy.request.girderToken = token
-        cherrypy.request.params = {}
-        try:
-            self._setStatus(rfolder, RunStatus.STARTING)
-            self._wait(5)
-            rdir = Path(rfolder['fsPath'])
-            resultsDir = rdir / 'results'
-
-            self._setStatus(rfolder, RunStatus.RUNNING)
-            with open(resultsDir / 'output.dat', 'w') as fo:
-                for _ in range(200):
-                    fo.write('data')
-                    fo.flush()
-                    self._stream(rfolder, '%s: Step %s\n' % (datetime.now(), _))
-                    self._wait(1)
-
-            self._setStatus(rfolder, RunStatus.COMPLETED)
-        except Exception as ex:  # NOQA
-            logger.warn('Exception faking run', ex)
-
-    def _wait(self, secs):
-        t.sleep(max(0.1, random.normalvariate(secs, math.sqrt(secs))))

--- a/server/resources/version.py
+++ b/server/resources/version.py
@@ -283,6 +283,8 @@ class Version(AbstractVRResource):
 
     @classmethod
     def _incrementReferenceCount(cls, vfolder):
+        if FIELD_REFERENCE_COUNTER not in vfolder:
+            vfolder[FIELD_REFERENCE_COUNTER] = 0
         cls._updateReferenceCount(vfolder, 1)
 
     @classmethod
@@ -294,10 +296,10 @@ class Version(AbstractVRResource):
         root = Folder().load(vfolder['parentId'], force=True)
         cls._setCriticalSectionFlag(root)
         try:
-            vfolder = Folder().load(vfolder['_id'], force=True)
-            if FIELD_REFERENCE_COUNTER in vfolder:
-                vfolder[FIELD_REFERENCE_COUNTER] += n
-                Folder().save(vfolder)
+            vfolder[FIELD_REFERENCE_COUNTER] += n
+            vfolder = Folder().save(vfolder)
+        except KeyError:
+            pass
         finally:
             cls._resetCriticalSectionFlag(root)
 

--- a/server/resources/version.py
+++ b/server/resources/version.py
@@ -38,17 +38,6 @@ class Version(AbstractVRResource):
         events.bind("rest.get.tale/:id/export.before", "wt_versioning", self.ensure_version)
         events.bind("rest.put.tale/:id/publish.before", "wt_versioning", self.ensure_version)
 
-    @access.user
-    @autoDescribeRoute(
-        Description('Clears all versions from a tale, but does not delete the respective '
-                    'directories on disk. This is an administrative operation and should not be'
-                    'used under normal circumstances.')
-        .modelParam('taleId', 'The ID of the tale for which the versions should be cleared',
-                    model=Tale, level=AccessType.ADMIN, destName='tale', paramType='query')
-    )
-    def clear(self, tale: dict) -> None:
-        super().clear(tale)
-
     @access.user(TokenScope.DATA_WRITE)
     @filtermodel('folder')
     @autoDescribeRoute(


### PR DESCRIPTION
This is ready for review now. There aren't many functional changes, I mostly added a lot of tests. However it should fix #14. Things noteworthy:

1. A reference counter on version gets properly updated whenever a run is created off the version or removed. As long as it's non zero, the version won't be removed from the system. It didn't work before, cause the counter was never properly initialized. Feel free to test it manually, but there's automatic check for that now too. Test case:
   1. Create a Tale, a version and a run.
   2. Try to remove the version. (it should fail)
   3. Remove the run, try to remove the version (it should succeed)
2. Fixed typo in `GET /run/:id` to make it work. As bonus filter the returned model correctly. Test case:
   1. Create a run via `POST /run`
   2. Check that `GET /run/:id` works
3. Fixed `GET /run` that was missing `user` kwarg.
   1. Assuming that you're doing things in order just see if `GET /run` gets you the run created in the previous step.
4. Removed testing endpoints since we now have proper tests.