### PR TITLE
Use FIELD_STATUS_CODE consistently

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -11,7 +11,7 @@ from girder.utility import setting_utilities
 from girder.plugins.wholetale.lib.manifest import Manifest
 from girder.plugins.wholetale.models.tale import Tale
 from .resources.version import Version, FIELD_CRITICAL_SECTION_FLAG
-from .resources.run import Run
+from .resources.run import Run, FIELD_STATUS_CODE
 from .constants import PluginSettings, Constants
 from .lib import util
 
@@ -132,7 +132,7 @@ def load(info):
         level=AccessType.READ, fields={"versionsRootId", "runsRootId", "restoredFrom"}
     )
     Folder().exposeFields(
-        level=AccessType.READ, fields={"runVersionId", "runStatus"}
+        level=AccessType.READ, fields={"runVersionId", FIELD_STATUS_CODE}
     )
 
     info['apiRoot'].version = Version(info["apiRoot"].tale)

--- a/server/resources/run.py
+++ b/server/resources/run.py
@@ -15,7 +15,7 @@ from ..constants import Constants, RunStatus, RunState
 from ..lib import util
 
 FIELD_SEQENCE_NUMBER = 'seq'
-FIELD_STATUS_CODE = 'runStatusCode'
+FIELD_STATUS_CODE = 'runStatus'
 RUN_NAME_FORMAT = '%c'
 
 
@@ -194,7 +194,7 @@ class Run(AbstractVRResource):
         runFolder = self._createSubdir(rootDir, root, name, user=self.getCurrentUser())
 
         runFolder['runVersionId'] = version['_id']
-        runFolder['runStatus'] = RunStatus.UNKNOWN.code
+        runFolder[FIELD_STATUS_CODE] = RunStatus.UNKNOWN.code
         Folder().save(runFolder, False)
 
         # Structure is:


### PR DESCRIPTION
Some parts of the code were using a global variable for denoting a run status code, and some parts were using a hardcoded string. Guess what? They didn't match... Now they do and as a bonus, the value of the global variable `FIELD_STATUS_CODE` matches what's in the Readme.