### PR TITLE
User removing a Tale is not necessarily its creator

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -59,9 +59,8 @@ def addVersionsAndRuns(event: events.Event) -> None:
 
 def removeVersionsAndRuns(event: events.Event) -> None:
     tale = event.info
-    creator = User().load(tale["creatorId"], force=True)
     for folder_id in (tale["runsRootId"], tale["versionsRootId"]):
-        root = Folder().load(folder_id, user=creator, level=AccessType.WRITE)
+        root = Folder().load(folder_id, force=True)
         Folder().remove(root)
     shutil.rmtree(util.getTaleVersionsDirPath(tale))
     shutil.rmtree(util.getTaleRunsDirPath(tale))


### PR DESCRIPTION
Whether this action can be performed (removing a Tale) is already verified on the Tale object. There are some edge cases when original creator is not the owner of a Tale being removed.