### PR TITLE
Use a proper workspaceId for a mock-restored tale

### DIFF
--- a/plugin_tests/versions_test.py
+++ b/plugin_tests/versions_test.py
@@ -233,6 +233,9 @@ class VersionTestCase(BaseTestCase):
             params={"versionId": version["_id"]},
         )
         self.assertStatusOk(resp)
+        view_tale = resp.json
+        self.assertTrue(view_tale["workspaceId"].startswith("wtlocal:"))
+        view_tale["workspaceId"] = first_version_tale["workspaceId"]
         self._compare_tales(resp.json, first_version_tale)
 
         # Restore First Version

--- a/server/resources/version.py
+++ b/server/resources/version.py
@@ -17,6 +17,7 @@ from girder.plugins.wholetale.lib.manifest import Manifest
 from girder.plugins.wholetale.lib.manifest_parser import ManifestParser
 from girder.plugins.wholetale.models.tale import Tale
 from girder.plugins.wt_data_manager.models.session import Session
+from girder.plugins.virtual_resources.rest import VirtualObject
 
 from ..constants import Constants
 from ..lib import util
@@ -218,6 +219,9 @@ class Version(AbstractVRResource):
     def restoreView(self, tale: dict, version: dict):
         version = Folder().load(version["_id"], force=True, fields=["fsPath"])
         tale.update(self._restoreTaleFromVersion(version))
+        tale["workspaceId"] = VirtualObject().generate_id(
+            Path(version["fsPath"]) / "workspace", version["_id"]
+        )
         return tale
 
     def _restoreTaleFromVersion(self, version, annotate=True):


### PR DESCRIPTION
### What changed?

`GET /tale/:id/restore` now points to an existing copy of a workspace in the version folder via `workspaceId`.

### Why did it change?

I need it for other work related to reproducible run docker image caching. Plus, it just makes more sense in case anything else uses that endpoint.

### How to test?
1. Create a versioned Tale.
2. Using swagger `GET /tale/:id/restore?versionId` and confirm that `workspaceId` points to a `<versionRoot>/workspace` (it's going to be `wtlocal:...` instead of `ObjectId()`).