### PR TITLE
Update run status based on job status

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -25,8 +25,8 @@ def validateOtherSettings(event):
 
 
 def setDefaults() -> None:
-    SettingDefault.defaults[PluginSettings.VERSIONS_DIRS_ROOT] = '/tmp/wt-versions-dirs'
-    SettingDefault.defaults[PluginSettings.RUNS_DIRS_ROOT] = '/tmp/wt-runs-dirs'
+    SettingDefault.defaults[PluginSettings.VERSIONS_DIRS_ROOT] = '/tmp/wt/versions'
+    SettingDefault.defaults[PluginSettings.RUNS_DIRS_ROOT] = '/tmp/wt/runs'
 
 
 def _createAuxFolder(tale, name, rootProp, creator):

--- a/server/resources/run.py
+++ b/server/resources/run.py
@@ -298,11 +298,7 @@ class Run(AbstractVRResource):
             rfolder = Folder().load(job['args'][0], force=True)
 
             # Store the previous status, if present.
-            previousStatus = -1
-            try:
-                previousStatus = rfolder[FIELD_STATUS_CODE]
-            except KeyError:
-                pass
+            previousStatus = rfolder.get(FIELD_STATUS_CODE, -1)
 
             if status == JobStatus.SUCCESS:
                 rfolder[FIELD_STATUS_CODE] = RunStatus.COMPLETED.code


### PR DESCRIPTION
This PR adds an event handler to update the run status based on job status.

To test:
* Requires https://github.com/whole-tale/gwvolman/pull/164
* Create an empty tale
* Start a recorded run with entrypoing `notfound.sh`
* Confirm job fails and run status is set to ERROR