### PR TITLE
Remove broken data symlink and results dir from run

### DIFF
--- a/server/resources/run.py
+++ b/server/resources/run.py
@@ -215,9 +215,7 @@ class Run(AbstractVRResource):
 
         # Structure is:
         #  @version -> ../Versions/<version> (link handled manually by FS)
-        #  @data -> version/data (link handled manualy by FS)
         #  @workspace -> version/workspace (same)
-        #  results
         #  .status
         #  .stdout (created using stream() above)
         #  .stderr (-''-)
@@ -227,14 +225,12 @@ class Run(AbstractVRResource):
         (runDir / 'version').symlink_to(
             f"../../../../versions/{tale_id[:2]}/{tale_id}/{version['_id']}", True
         )
-        (runDir / 'data').symlink_to('version/data', True)
         (runDir / 'workspace').mkdir()
         self._snapshotRecursive(
             None,
             (runDir / "version" / "workspace"),
             (runDir / "workspace")
         )
-        (runDir / 'results').mkdir()
         self._write_status(runDir, RunStatus.UNKNOWN)
 
         return runFolder


### PR DESCRIPTION
This PR **proposes** that we remove the broken `run/data` symlink and `results` directory.

The data directory hasn't worked for a while, just a broken symlink. The `version/data` directory was removed in a previous PR, as I recall because of complexity handling versioned data caching (the user can see what data was used via versioned manifest anyway). The `results` directory was proposed, but we never reached consensus, is undocumented and seems to offer little over a results directory in the workspace, which the user has full control over. Also, results is not part of the exported bag and can be deferred, if desired, to a future release.

To test:
* Create a tale with a recorded run
* Confirm results and data directories are not present