### PR TITLE
Separate internal API from REST API

### DIFF
--- a/server/constants.py
+++ b/server/constants.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+FIELD_STATUS_CODE = "runStatus"
+
 
 class Constants:
     VERSIONS_ROOT_DIR_NAME = "WholeTale Tale Versions"

--- a/server/lib/hierarchy.py
+++ b/server/lib/hierarchy.py
@@ -1,0 +1,263 @@
+import json
+import os
+import shutil
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+import pathvalidate
+from girder import logger
+from girder.constants import AccessType
+from girder.exceptions import RestException
+from girder.models.folder import Folder
+from girder.plugins.wholetale.lib.manifest import Manifest
+from girder.plugins.wholetale.models.tale import Tale
+
+
+class AbstractHierarchyModel(object):
+    root_tale_field = None
+    field_sequence_number = "seq"
+    name_format = "%c"
+    field_critical_section_flag = None
+    field_reference_counter = None
+
+    def __new__(cls):
+        if not hasattr(cls, "instance"):
+            cls.instance = super(AbstractHierarchyModel, cls).__new__(cls)
+        return cls.instance
+
+    def getRootFromTale(self, tale: dict, user=None, level=AccessType.READ) -> dict:
+        if user:
+            kwargs = dict(user=user, level=level)
+        else:
+            kwargs = dict(force=True)
+        return Folder().load(tale[self.root_tale_field], exc=True, **kwargs)
+
+    @staticmethod
+    def checkNameSanity(
+        name: Optional[str],
+        parentFolder: dict,
+        allow_rename: bool = False,
+    ) -> str:
+        if not name:
+            raise RestException("Name cannot be empty.", code=400)
+
+        try:
+            pathvalidate.validate_filename(name, platform="Linux")
+        except pathvalidate.ValidationError:
+            raise RestException("Invalid file name: " + name, code=400)
+
+        q = {"parentId": parentFolder["_id"], "name": name}
+        if not allow_rename and Folder().findOne(q, fields=["_id"]):
+            raise RestException("Name already exists: " + name, code=409)
+
+        n = 0
+        while Folder().findOne(q, fields=["_id"]):
+            n += 1
+            q["name"] = f"{name} ({n})"
+            if n > 100:
+                break
+        return q["name"]
+
+    @staticmethod
+    def createSubdir(rootDir: Path, rootFolder: dict, name: str, user=None) -> dict:
+        """Create both Girder folder and corresponding directory. The name is stored in the Girder
+        folder, whereas the name of the directory is taken from the folder ID. This is a
+        deliberate step to discourage renaming of directories directly on disk, which would mess
+        up the mapping between Girder folders and directories
+        """
+        folder = Folder().createFolder(rootFolder, name, creator=user)
+        dirname = str(folder["_id"])
+        directory = rootDir / dirname
+        directory.mkdir(parents=True)
+        folder.update({"fsPath": directory.absolute().as_posix(), "isMapping": True})
+        folder = Folder().save(folder, validate=False, triggerEvents=False)
+
+        # update the time
+        Folder().updateFolder(rootFolder)
+        return folder
+
+    def snapshot(
+        self,
+        version: Optional[dict],
+        tale: dict,
+        new_version: dict,
+        user=None,
+        force=False,
+    ) -> None:
+        """Creates a new version from the current state and an old version. The implementation
+        here differs a bit from
+        https://docs.google.com/document/d/1b2xZtIYvgVXz7EVeV-C18So_a7QLGg59dPQMxvBcA5o since
+        the document assumes traditional use of Girder objects to simulate a filesystem, whereas
+        the current reality is that we are moving more towards Girder being a thin layer on top
+        of an actual FS (i.e. virtual_resources). In particular, the data folder remains in the
+        domain of the DMS, meaning that actual files are only downloaded on demand. The current
+        implementation of the virtual objects does not seem to have a straightforward way of
+        embedding pure girder folders inside a virtual tree. The solution currently adopted to
+        address this issue involves storing the dataset in the version folder itself, which, for
+        efficiency reasons remains a Girder folder (but also a virtual_resources root).
+
+        It may be relevant to note that this implementation uses option (b) in the above document
+        with respect to the meaning of "copy" in step 4.1.2.1. To be more precise, when a file is
+        changed in the current workspace, the new version will hard link to the file in question
+        instead of doing an actual copy. This allows for O(1) equality comparisons between files,
+        but requires that modifications to files in the workspace always create a new file (which
+        is the case if files are only modified through the WebDAV FS mounted in a tale container).
+        """
+        new_version_path = Path(new_version["fsPath"])
+        manifest = Manifest(
+            tale, user, versionId=new_version["_id"], expand_folders=False
+        )
+        with open((new_version_path / "manifest.json").as_posix(), "w") as fp:
+            fp.write(manifest.dump_manifest())
+
+        with open((new_version_path / "environment.json").as_posix(), "w") as fp:
+            fp.write(manifest.dump_environment())
+
+        oldWorkspace = (
+            None if version is None else Path(version["fsPath"]) / "workspace"
+        )
+        workspace = Folder().load(tale["workspaceId"], force=True)
+        crtWorkspace = Path(workspace["fsPath"])
+        newWorkspace = new_version_path / "workspace"
+        newWorkspace.mkdir()
+        self.snapshotRecursive(oldWorkspace, crtWorkspace, newWorkspace)
+
+    def is_same(self, tale, version, user):
+        workspace = Folder().load(tale["workspaceId"], force=True)
+        tale_workspace_path = Path(workspace["fsPath"])
+
+        version_path = None if version is None else Path(version["fsPath"])
+        version_workspace_path = (
+            None if version_path is None else version_path / "workspace"
+        )
+
+        manifest_obj = Manifest(tale, user)
+        manifest = json.loads(manifest_obj.dump_manifest())
+        environment = json.loads(manifest_obj.dump_environment())
+        tale_restored_from_wrk = Tale().restoreTale(manifest, environment)
+        tale_restored_from_ver = (
+            self.restoreTaleFromVersion(version, annotate=False) if version else None
+        )
+
+        if self.sameTaleMetadata(
+            tale_restored_from_ver, tale_restored_from_wrk
+        ) and self.sameTree(version_workspace_path, tale_workspace_path):
+            raise RestException("Not modified", code=303, extra=str(version["_id"]))
+
+    def snapshotRecursive(self, old: Optional[Path], crt: Path, new: Path) -> None:
+        for c in crt.iterdir():
+            newc = new / c.name
+            oldc = None if old is None else old / c.name
+            crtc = crt / c.name
+
+            if oldc is not None:
+                if not oldc.exists():
+                    oldc = None
+                else:
+                    if crtc.is_dir() != oldc.is_dir():
+                        # either oldc was a dir and is now a file or the other way around
+                        oldc = None
+
+            if c.is_dir():
+                newc.mkdir()
+                self.snapshotRecursive(oldc, crtc, newc)
+            else:
+                crtcstr = crtc.absolute()
+                newcstr = newc.absolute()
+                try:
+                    os.link(crtcstr.as_posix(), newcstr.as_posix())
+                except:  # noqa: E722
+                    logger.warn("link %s -> %s" % (crtcstr, newcstr))
+                    raise
+                shutil.copystat(crtcstr, newcstr)
+
+    def incrementReferenceCount(self, vfolder):
+        if self.field_reference_counter not in vfolder:
+            vfolder[self.field_reference_counter] = 0
+        self.updateReferenceCount(vfolder, 1)
+
+    def decrementReferenceCount(self, vfolder):
+        self.updateReferenceCount(vfolder, -1)
+
+    def updateReferenceCount(self, vfolder: dict, n: int):
+        root = Folder().load(vfolder["parentId"], force=True)
+        self.setCriticalSectionFlag(root)
+        try:
+            vfolder[self.field_reference_counter] += n
+            vfolder = Folder().save(vfolder)
+        except KeyError:
+            pass
+        finally:
+            self.resetCriticalSectionFlag(root)
+
+    def setCriticalSectionFlag(self, root: dict) -> bool:
+        return self.updateCriticalSectionFlag(root, True)
+
+    def resetCriticalSectionFlag(self, root: dict) -> bool:
+        return self.updateCriticalSectionFlag(root, False)
+
+    def updateCriticalSectionFlag(self, root: dict, value: bool) -> bool:
+        result = Folder().update(
+            query={
+                "_id": root["_id"],
+                self.field_critical_section_flag: {"$ne": value},
+            },
+            update={
+                "$set": {self.field_critical_section_flag: value},
+                "$inc": {self.field_sequence_number: 1},
+            },
+            multi=False,
+        )
+        return result.matched_count > 0
+
+    def generateName(self):
+        now = datetime.now()
+        return now.strftime(self.name_format)
+
+    @staticmethod
+    def sameTaleMetadata(old: Optional[dict], crt: dict):
+        if old is None:
+            return False
+        return old == crt
+
+    def sameTree(self, old: Optional[Path], crt: Path) -> bool:
+        if old is None:
+            return False
+        for c in crt.iterdir():
+            oldc = old / c.name
+            crtc = crt / c.name
+
+            if not oldc.exists():
+                return False
+
+            if crtc.is_dir() != oldc.is_dir():
+                return False
+
+            if crtc.is_dir():
+                if not self.sameTree(oldc, crtc):
+                    return False
+            else:
+                if not oldc.samefile(crtc):
+                    return False
+        return True
+
+    def remove(self, version: dict, user: dict) -> None:
+        root = Folder().load(version["parentId"], user=user, level=AccessType.WRITE)
+        self.setCriticalSectionFlag(root)
+        try:
+            # make sure we use information protected by the critical section
+            version = Folder().load(version["_id"], user=user, level=AccessType.ADMIN)
+            if version.get(self.field_reference_counter, 0) > 0:
+                raise RestException(
+                    "Version is in use by a run and cannot be deleted.", 461
+                )
+        finally:
+            self.resetCriticalSectionFlag(root)
+
+        path = Path(version["fsPath"])
+        trashDir = path.parent / ".trash"
+        Folder().remove(version)
+
+        shutil.move(path.as_posix(), trashDir)
+        Tale().updateTale(Tale().load(root["taleId"], force=True))

--- a/server/lib/run_hierarchy.py
+++ b/server/lib/run_hierarchy.py
@@ -1,0 +1,94 @@
+import shutil
+from pathlib import Path
+from typing import Optional, Union
+
+from girder.constants import AccessType
+from girder.models.folder import Folder
+from girder.plugins.wholetale.models.tale import Tale
+from . import util
+from .hierarchy import AbstractHierarchyModel
+from .version_hierarchy import VersionHierarchyModel
+from ..constants import FIELD_STATUS_CODE, RunStatus, RunState
+
+
+class RunHierarchyModel(AbstractHierarchyModel):
+    root_tale_field = "runsRootId"
+
+    def getStatus(self, rfolder: dict) -> dict:
+        if FIELD_STATUS_CODE in rfolder:
+            rs = RunStatus.get(rfolder[FIELD_STATUS_CODE])
+        else:
+            rs = RunStatus.UNKNOWN
+        return {"status": rs.code, "statusString": rs.name}
+
+    def setStatus(self, rfolder: dict, status: Union[int, RunState]) -> None:
+        # TODO: add heartbeats (runs must regularly update status, otherwise they are considered
+        # failed)
+        if isinstance(status, int):
+            _status = RunState.ALL[status]
+        else:
+            _status = status
+        rfolder[FIELD_STATUS_CODE] = _status.code
+        Folder().save(rfolder)
+        runDir = Path(rfolder["fsPath"])
+        self.write_status(runDir, _status)
+
+    def create(
+        self, version: dict, name: Optional[str], user: dict, allowRename: bool = False
+    ) -> dict:
+        if not name:
+            name = self.generateName()
+
+        versionsRoot = Folder().load(
+            version["parentId"], user=user, level=AccessType.WRITE
+        )
+        taleId = versionsRoot["taleId"]
+        tale = Tale().load(taleId, user=user, level=AccessType.WRITE)
+        root = self.getRootFromTale(tale, user=user, level=AccessType.WRITE)
+        name = self.checkNameSanity(name, root, allow_rename=allowRename)
+
+        rootDir = util.getTaleRunsDirPath(tale)
+
+        runFolder = self.createSubdir(rootDir, root, name, user=user)
+
+        runFolder["runVersionId"] = version["_id"]
+        runFolder[FIELD_STATUS_CODE] = RunStatus.UNKNOWN.code
+        Folder().save(runFolder, False)
+
+        # Structure is:
+        #  @version -> ../Versions/<version> (link handled manually by FS)
+        #  @workspace -> version/workspace (same)
+        #  .status
+        #  .stdout (created using stream() above)
+        #  .stderr (-''-)
+        runDir = Path(runFolder["fsPath"])
+        tale_id = runDir.parts[-2]
+        # TODO: a lot assumptions hardcoded below...
+        (runDir / "version").symlink_to(
+            f"../../../../versions/{tale_id[:2]}/{tale_id}/{version['_id']}", True
+        )
+        (runDir / "workspace").mkdir()
+        self.snapshotRecursive(
+            None, (runDir / "version" / "workspace"), (runDir / "workspace")
+        )
+        self.write_status(runDir, RunStatus.UNKNOWN)
+
+        Tale().updateTale(tale)
+        VersionHierarchyModel().incrementReferenceCount(version)
+
+        return runFolder
+
+    @staticmethod
+    def write_status(runDir: Path, status: RunState):
+        with open(runDir / ".status", "w") as f:
+            f.write("%s %s" % (status.code, status.name))
+
+    def remove(self, rfolder: dict, user: dict) -> None:
+        path = Path(rfolder["fsPath"])
+        trashDir = path.parent / ".trash"
+        version = Folder().load(
+            rfolder["runVersionId"], level=AccessType.WRITE, user=user
+        )
+        Folder().remove(rfolder)
+        shutil.move(path.as_posix(), trashDir)
+        VersionHierarchyModel().decrementReferenceCount(version)

--- a/server/lib/version_hierarchy.py
+++ b/server/lib/version_hierarchy.py
@@ -1,0 +1,113 @@
+from bson import ObjectId
+import json
+import shutil
+from pathlib import Path
+import pymongo
+from typing import Optional
+
+from girder import logger
+from girder.constants import AccessType
+from girder.exceptions import RestException
+from girder.models.folder import Folder
+from girder.plugins.wholetale.models.tale import Tale
+from .hierarchy import AbstractHierarchyModel
+
+
+class VersionHierarchyModel(AbstractHierarchyModel):
+    root_tale_field = "versionsRootId"
+    field_critical_section_flag = "versionsCriticalSectionFlag"
+    field_reference_counter = "versionsRefCount"
+
+    def create(
+        self,
+        tale: dict,
+        name: Optional[str],
+        versionsDir: Path,
+        versionsRoot: dict,
+        user=None,
+        force=False,
+    ) -> dict:
+        last = self.getLastVersion(versionsRoot)
+        last_restore = Folder().load(tale.get("restoredFrom", ObjectId()), force=True)
+        workspace = Folder().load(tale["workspaceId"], force=True)
+        crtWorkspace = Path(workspace["fsPath"])
+
+        # NOTE: order is important, we want oldWorkspace -> last.workspace
+        for version in (last_restore, last):
+            oldWorkspace = (
+                None if version is None else Path(version["fsPath"]) / "workspace"
+            )
+            if (
+                not force
+                and self.is_same(tale, version, user)
+                and self.sameTree(oldWorkspace, crtWorkspace)
+            ):
+                assert version is not None
+                raise RestException("Not modified", code=303, extra=str(version["_id"]))
+
+        new_version = self.createSubdir(versionsDir, versionsRoot, name, user=user)
+
+        try:
+            self.snapshot(last, tale, new_version, user=user, force=force)
+            return new_version
+        except Exception:  # NOQA
+            try:
+                shutil.rmtree(new_version["fsPath"])
+                Folder().remove(new_version)
+            except Exception as ex:  # NOQA
+                logger.warning(
+                    "Exception caught while rolling back version ckeckpoint.", ex
+                )
+            raise
+
+    def getLastVersion(self, versionsFolder: dict) -> Optional[dict]:
+        # The versions root folder is kept as a pure Girder folder.
+        # This is because there is no efficient way to
+        # say "give me the latest subdir" on a POSIX filesystem.
+        return Folder().findOne(
+            {"parentId": versionsFolder["_id"]}, sort=[("created", pymongo.DESCENDING)]
+        )
+
+    def restore(self, tale: dict, version: dict, user: dict):
+        version_root = Folder().load(
+            version["parentId"], user=user, level=AccessType.READ
+        )
+
+        workspace = Folder().load(tale["workspaceId"], force=True)
+        workspace_path = Path(workspace["fsPath"])
+        version = Folder().load(version["_id"], force=True, fields=["fsPath"])
+        version_workspace_path = Path(version["fsPath"]) / "workspace"
+
+        if not self.setCriticalSectionFlag(version_root):
+            raise RestException(
+                "Another operation is in progress. Try again later.", 409
+            )
+        try:
+            # restore workspace
+            shutil.rmtree(workspace_path)
+            workspace_path.mkdir()
+            self.snapshotRecursive(None, version_workspace_path, workspace_path)
+            # restore Tale
+            tale.update(self.restoreTaleFromVersion(version))
+            return Tale().save(tale)
+        finally:
+            # probably need a better way to deal with hard crashes here
+            self.resetCriticalSectionFlag(version_root)
+
+    @staticmethod
+    def restoreTaleFromVersion(version, annotate=True):
+        version_path = Path(version["fsPath"])
+        with open((version_path / "manifest.json").as_posix(), "r") as fp:
+            manifest = json.load(fp)
+        with open((version_path / "environment.json").as_posix(), "r") as fp:
+            env = json.load(fp)
+        restored_tale = Tale().restoreTale(manifest, env)
+        if annotate:
+            restored_tale["restoredFrom"] = version["_id"]
+        return restored_tale
+
+    def resetCrashedCriticalSections(self):
+        Folder().update(
+            {self.field_critical_section_flag: True},
+            {"$set": {self.field_critical_section_flag: False}},
+        )

--- a/server/resources/abstract_resource.py
+++ b/server/resources/abstract_resource.py
@@ -1,11 +1,5 @@
 import os
-from pathlib import Path
-import shutil
-from typing import Optional
-
-import pathvalidate
-
-from girder import events, logger
+from girder import events
 from girder.api import access
 from girder.constants import AccessType, TokenScope
 from girder.api.v1.resource import Resource
@@ -17,6 +11,7 @@ from girder.plugins.wholetale.models.tale import Tale
 
 class AbstractVRResource(Resource):
     root_tale_field = None
+    model = None
 
     def __init__(self, resourceName, rootDirName):
         Resource.__init__(self)
@@ -33,64 +28,12 @@ class AbstractVRResource(Resource):
         self.route('PUT', (':id',), self.rename)
         self.route('DELETE', (':id',), self.delete)
 
-    def _getRootFromTale(self, tale: dict, user=None, level=AccessType.READ) -> dict:
-        if user:
-            kwargs = dict(user=user, level=level)
-        else:
-            kwargs = dict(force=True)
-        return Folder().load(tale[self.root_tale_field], exc=True, **kwargs)
-
-    def _checkNameSanity(
-        self,
-        name: Optional[str],
-        parentFolder: dict,
-        allow_rename: bool = False,
-    ) -> str:
-        if not name:
-            raise RestException('Name cannot be empty.', code=400)
-
-        try:
-            pathvalidate.validate_filename(name, platform='Linux')
-        except pathvalidate.ValidationError:
-            raise RestException('Invalid file name: ' + name, code=400)
-
-        q = {'parentId': parentFolder['_id'], 'name': name}
-        if not allow_rename and Folder().findOne(q, fields=["_id"]):
-            raise RestException('Name already exists: ' + name, code=409)
-
-        n = 0
-        while Folder().findOne(q, fields=["_id"]):
-            n += 1
-            q["name"] = f"{name} ({n})"
-            if n > 100:
-                break
-        return q["name"]
-
-    def _createSubdir(
-        self, rootDir: Path, rootFolder: dict, name: str, user=None
-    ) -> dict:
-        """Create both Girder folder and corresponding directory. The name is stored in the Girder
-        folder, whereas the name of the directory is taken from the folder ID. This is a
-        deliberate step to discourage renaming of directories directly on disk, which would mess
-        up the mapping between Girder folders and directories
-        """
-        folder = Folder().createFolder(rootFolder, name, creator=user)
-        dirname = str(folder['_id'])
-        dir = rootDir / dirname
-        dir.mkdir(parents=True)
-        folder.update({'fsPath': dir.absolute().as_posix(), 'isMapping': True})
-        folder = Folder().save(folder, validate=False, triggerEvents=False)
-
-        # update the time
-        Folder().updateFolder(rootFolder)
-        return folder
-
     def rename(self, vrfolder: dict, newName: str, allow_rename: bool = False) -> dict:
         user = self.getCurrentUser()
         if not newName:
             raise RestException('New name cannot be empty.', code=400)
         root = Folder().load(vrfolder['parentId'], user=user, level=AccessType.WRITE)
-        newName = self._checkNameSanity(newName, root, allow_rename=allow_rename)
+        newName = self.model.checkNameSanity(newName, root, allow_rename=allow_rename)
         vrfolder.update({'name': newName})
         os.utime(vrfolder["fsPath"])
         os.utime(os.path.dirname(vrfolder["fsPath"]))
@@ -120,7 +63,7 @@ class AbstractVRResource(Resource):
         filters=None,
         **kwargs
     ):
-        root = self._getRootFromTale(tale, user=user, level=AccessType.READ)
+        root = self.model.getRootFromTale(tale, user=user, level=AccessType.READ)
         return Folder().childFolders(
             root,
             "folder",
@@ -134,36 +77,9 @@ class AbstractVRResource(Resource):
 
     def exists(self, tale: dict, name: str):
         user = self.getCurrentUser()
-        root = self._getRootFromTale(tale, user=user, level=AccessType.READ)
+        root = self.model.getRootFromTale(tale, user=user, level=AccessType.READ)
         obj = Folder().findOne({'parentId': root['_id'], 'name': name})
         if obj is None:
             return {'exists': False}
         else:
             return {'exists': True, 'obj': Folder().filter(obj, self.getCurrentUser())}
-
-    def _snapshotRecursive(self, old: Optional[Path], crt: Path, new: Path) -> None:
-        for c in crt.iterdir():
-            newc = new / c.name
-            oldc = None if old is None else old / c.name
-            crtc = crt / c.name
-
-            if oldc is not None:
-                if not oldc.exists():
-                    oldc = None
-                else:
-                    if crtc.is_dir() != oldc.is_dir():
-                        # either oldc was a dir and is now a file or the other way around
-                        oldc = None
-
-            if c.is_dir():
-                newc.mkdir()
-                self._snapshotRecursive(oldc, crtc, newc)
-            else:
-                crtcstr = crtc.absolute().as_posix()
-                newcstr = newc.absolute().as_posix()
-                try:
-                    os.link(crtcstr, newcstr)
-                except:  # noqa: E722
-                    logger.warn('link %s -> %s' % (crtcstr, newcstr))
-                    raise
-                shutil.copystat(crtcstr, newcstr)

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,4 +55,4 @@ exclude: girder/external/*
 #     N806 - Variable in function should be lowercase.
 #     N812 - Lowercase imported as non lowercase.
 #     W606 - 'async' and 'await' are reserved keywords starting with Python 3.7
-ignore: D100,D101,D102,D103,D104,D105,D107,D200,D201,D202,D203,D204,D205,D400,D401,D402,E123,E226,E241,N802,N803,N806,N812,W606
+ignore: D100,D101,D102,D103,D104,D105,D107,D200,D201,D202,D203,D204,D205,D400,D401,D402,E123,E226,E241,N802,N803,N806,N812,W606,W503


### PR DESCRIPTION
This is just a bit of refactoring code around. The main purpose is to separate REST layer from actual things happening on disk or with girder models. It makes it easier to reuse the code this way. 

### How to test?
1. It should be a noop. Follow the release test plan in sections related to versions and runs to confirm nothing is broken.