### PR TITLE
Change get/list operations to public

### DIFF
--- a/server/resources/run.py
+++ b/server/resources/run.py
@@ -30,7 +30,7 @@ class Run(AbstractVRResource):
         events.bind('jobs.job.update.after', 'wt_versioning', self.updateRunStatus)
         self.model = RunHierarchyModel()
 
-    @access.user()
+    @access.public
     @filtermodel('folder')
     @autoDescribeRoute(
         Description('Retrieves the runs root folder for this tale.')
@@ -56,7 +56,7 @@ class Run(AbstractVRResource):
     def rename(self, rfolder: dict, name: str) -> dict:
         return super().rename(rfolder, name)
 
-    @access.user(TokenScope.DATA_READ)
+    @access.public
     @filtermodel('folder')
     @autoDescribeRoute(
         Description('Returns a run.')
@@ -101,7 +101,7 @@ class Run(AbstractVRResource):
     def delete(self, rfolder: dict) -> None:
         self.model.remove(rfolder, self.getCurrentUser())
 
-    @access.user(TokenScope.DATA_READ)
+    @access.public
     @filtermodel('folder')
     @autoDescribeRoute(
         Description('Lists runs.')

--- a/server/resources/version.py
+++ b/server/resources/version.py
@@ -75,7 +75,7 @@ class Version(AbstractVRResource):
         Session().loadObjects(dataSet)
         return dataSet
 
-    @access.user(TokenScope.DATA_READ)
+    @access.public
     @filtermodel("folder")
     @autoDescribeRoute(
         Description('Returns a version.')
@@ -206,7 +206,7 @@ class Version(AbstractVRResource):
     def delete(self, version: dict) -> None:
         self.model.remove(version, self.getCurrentUser())
 
-    @access.user(TokenScope.DATA_READ)
+    @access.public
     @filtermodel('folder')
     @autoDescribeRoute(
         Description('Lists versions.')


### PR DESCRIPTION
**Problem**:
Non-logged-in users cannot see versions or runs associated with a public tale.

**Approach**:
Change access to list and load operations to public.

**To Test**:
* Requires https://github.com/whole-tale/ngx-dashboard/pull/277
* As a logged-in user, create a public tale with versions and runs
* As a non-logged in user, confirm that you can see versions/runs and download files.