### PR TITLE
fix: set rrun's girderToken validity to 60d

### DIFF
--- a/plugin_tests/copy_test.py
+++ b/plugin_tests/copy_test.py
@@ -1,4 +1,5 @@
 import json
+import mock
 import os
 import time
 
@@ -28,7 +29,13 @@ def tearDownModule():
 
 
 class CopyVersionAndRunsTestCase(BaseTestCase):
-    def testCopyVersion(self):
+
+    @mock.patch("girder.plugins.wholetale.lib.manifest.ImageBuilder")
+    def testCopyVersion(self, mock_builder):
+        mock_builder.return_value.container_config.repo2docker_version = \
+            "craigwillis/repo2docker:latest"
+        mock_builder.return_value.get_tag.return_value = \
+            "some_image_digest"
         tale = self._create_example_tale(self.get_dataset([0]))
         workspace = Folder().load(tale["workspaceId"], force=True)
 
@@ -80,7 +87,12 @@ class CopyVersionAndRunsTestCase(BaseTestCase):
         self.assertStatusOk(resp)
         self._remove_example_tale(tale)
 
-    def testFullCopy(self):
+    @mock.patch("girder.plugins.wholetale.lib.manifest.ImageBuilder")
+    def testFullCopy(self, mock_builder):
+        mock_builder.return_value.container_config.repo2docker_version = \
+            "craigwillis/repo2docker:latest"
+        mock_builder.return_value.get_tag.return_value = \
+            "some_image_digest"
         tale = self._create_example_tale(self.get_dataset([0]))
         workspace = Folder().load(tale["workspaceId"], force=True)
 

--- a/plugin_tests/runs_test.py
+++ b/plugin_tests/runs_test.py
@@ -29,7 +29,13 @@ def tearDownModule():
 
 
 class RunsTestCase(BaseTestCase):
-    def testBasicRunsOps(self):
+    @mock.patch("girder.plugins.wholetale.lib.manifest.ImageBuilder")
+    def testBasicRunsOps(self, mock_builder):
+        mock_builder.return_value.container_config.repo2docker_version = \
+            "craigwillis/repo2docker:latest"
+        mock_builder.return_value.get_tag.return_value = \
+            "some_image_digest"
+
         tale = self._create_example_tale(self.get_dataset([0]))
         workspace = Folder().load(tale["workspaceId"], force=True)
 
@@ -167,8 +173,13 @@ class RunsTestCase(BaseTestCase):
         )
         self.assertStatusOk(resp)
 
-    @mock.patch('gwvolman.tasks.recorded_run')
-    def testRecordedRun(self, rr):
+    @mock.patch("gwvolman.tasks.recorded_run")
+    @mock.patch("girder.plugins.wholetale.lib.manifest.ImageBuilder")
+    def testRecordedRun(self, rr, mock_builder):
+        mock_builder.return_value.container_config.repo2docker_version = \
+            "craigwillis/repo2docker:latest"
+        mock_builder.return_value.get_tag.return_value = \
+            "some_image_digest"
         tale = self._create_example_tale(self.get_dataset([0]))
         workspace = Folder().load(tale["workspaceId"], force=True)
 

--- a/plugin_tests/versions_test.py
+++ b/plugin_tests/versions_test.py
@@ -1,6 +1,7 @@
 from bson import ObjectId
 import copy
 import json
+import mock
 import os
 import pathlib
 import time
@@ -47,8 +48,14 @@ class VersionTestCase(BaseTestCase):
                 print(key)
                 raise
 
-    def testBasicVersionOps(self):
+    @mock.patch("girder.plugins.wholetale.lib.manifest.ImageBuilder")
+    def testBasicVersionOps(self, mock_builder):
         from girder.plugins.wt_versioning.constants import PluginSettings
+
+        mock_builder.return_value.container_config.repo2docker_version = \
+            "craigwillis/repo2docker:latest"
+        mock_builder.return_value.get_tag.return_value = \
+            "some_image_digest"
 
         tale = self._create_example_tale(self.get_dataset([0]))
         workspace = Folder().load(tale["workspaceId"], force=True)
@@ -360,7 +367,12 @@ class VersionTestCase(BaseTestCase):
         # Clean up
         self._remove_example_tale(tale)
 
-    def testDatasetHandling(self):
+    @mock.patch("girder.plugins.wholetale.lib.manifest.ImageBuilder")
+    def testDatasetHandling(self, mock_builder):
+        mock_builder.return_value.container_config.repo2docker_version = \
+            "craigwillis/repo2docker:latest"
+        mock_builder.return_value.get_tag.return_value = \
+            "some_image_digest"
         tale = self._create_example_tale(dataset=self.get_dataset([0]))
         resp = self.request(
             path="/version",
@@ -381,7 +393,12 @@ class VersionTestCase(BaseTestCase):
 
         self._remove_example_tale(tale)
 
-    def test_force_version(self):
+    @mock.patch("girder.plugins.wholetale.lib.manifest.ImageBuilder")
+    def test_force_version(self, mock_builder):
+        mock_builder.return_value.container_config.repo2docker_version = \
+            "craigwillis/repo2docker:latest"
+        mock_builder.return_value.get_tag.return_value = \
+            "some_image_digest"
         tale = self._create_example_tale(dataset=self.get_dataset([0]))
         # Check that the tale has no versions.
         resp = self.request(

--- a/server/resources/run.py
+++ b/server/resources/run.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import Union
 
 from girder import events
@@ -181,7 +182,8 @@ class Run(AbstractVRResource):
             'tale_title': tale['title']
         }
 
-        token = Token().createToken(user=user, days=0.5)
+        # Recorded run can run for a long time. Should we set a limit?
+        token = Token().createToken(user=user, days=60)
 
         notification = init_progress(
             resource, user, 'Recorded run',
@@ -197,6 +199,18 @@ class Run(AbstractVRResource):
 
         return Job().filter(rrTask.job, user=user)
 
+    @staticmethod
+    def _expire_job_token(job):
+        """Given a job's girderToken in headers set its expiration to 1h"""
+        try:
+            token_id = job["jobInfoSpec"]["headers"]["Girder-Token"]
+        except KeyError:
+            return
+
+        if token := Token().load(token_id, force=True, objectId=False):
+            token["expires"] = datetime.datetime.utcnow() + datetime.timedelta(hours=1)
+            Token().save(token)
+
     def updateRunStatus(self, event):
         """
         Event handler that updates the run status based on the recorded_run task.
@@ -211,8 +225,10 @@ class Run(AbstractVRResource):
 
             if status == JobStatus.SUCCESS:
                 rfolder[FIELD_STATUS_CODE] = RunStatus.COMPLETED.code
+                self._expire_job_token(job)
             elif status == JobStatus.ERROR:
                 rfolder[FIELD_STATUS_CODE] = RunStatus.FAILED.code
+                self._expire_job_token(job)
             elif status in (JobStatus.QUEUED, JobStatus.RUNNING):
                 rfolder[FIELD_STATUS_CODE] = RunStatus.RUNNING.code
 

--- a/server/resources/run.py
+++ b/server/resources/run.py
@@ -193,8 +193,9 @@ class Run(AbstractVRResource):
             args=[str(run['_id']), str(tale['_id']), entrypoint],
             girder_job_other_fields={
                 'wt_notification_id': str(notification['_id']),
+                'token': token["_id"],
             },
-            girder_client_token=str(token['_id']),
+            girder_client_token=token["_id"],
         ).apply_async()
 
         return Job().filter(rrTask.job, user=user)


### PR DESCRIPTION
In order to fix #48, I set Token expiration value to 60d (hopefully enough). However, I also added cleaning up tokens that are associated with finished rruns (both successful and failed).